### PR TITLE
feat(query): add duration_ms synthetic span field

### DIFF
--- a/internal/query/builder.go
+++ b/internal/query/builder.go
@@ -376,6 +376,8 @@ func (b *builder) realColumn(name string) (resolvedField, bool) {
 			return resolvedField{SQL: "status_code", Type: "int"}, true
 		case "duration_ns":
 			return resolvedField{SQL: "duration_ns", Type: "int"}, true
+		case "duration_ms":
+			return resolvedField{SQL: "(duration_ns / 1000000)", Type: "int"}, true
 		case "start_time_ns":
 			return resolvedField{SQL: "start_time_ns", Type: "time"}, true
 		case "parent_span_id":

--- a/internal/query/builder_test.go
+++ b/internal/query/builder_test.go
@@ -594,3 +594,37 @@ func TestBuild_ContainsFilter(t *testing.T) {
 		t.Errorf("contains arg wrapping: want %%refused%%, got %v", got)
 	}
 }
+
+// duration_ms is a synthetic field derived from duration_ns / 1_000_000. It
+// should compile as an expression (not a raw column), and the percentile
+// aggregation's output alias should use the user-supplied field name so the
+// column shows up as p99_duration_ms rather than p99_duration_ns.
+func TestBuild_DurationMSField(t *testing.T) {
+	q := Query{
+		Dataset:   DatasetSpans,
+		TimeRange: tr(),
+		Select: []Aggregation{
+			{Op: OpP99, Field: "duration_ms"},
+		},
+		Where:   []Filter{{Field: "duration_ms", Op: FilterGt, Value: 100}},
+		GroupBy: []string{"service.name"},
+		OrderBy: []Order{{Field: "p99_duration_ms", Dir: "desc"}},
+	}
+	if err := q.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	c, err := Build(&q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"percentile((duration_ns / 1000000), 0.99) AS p99_duration_ms",
+		"(duration_ns / 1000000) > ?",
+		"ORDER BY p99_duration_ms DESC",
+	}
+	for _, s := range want {
+		if !strings.Contains(c.SQL, s) {
+			t.Errorf("SQL missing %q; got:\n%s", s, c.SQL)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `duration_ms` as a span meta field so users can query in milliseconds directly:

```json
{ "op": "p99", "field": "duration_ms" }
```

Resolves to the SQL expression `(duration_ns / 1000000)` via `realColumn` — same machinery the existing `error` synthetic uses. Works across select/where/group_by/having/order_by, and the percentile output alias follows the user's field name (`p99_duration_ms`, not `p99_duration_ns`).

## Notes

- Integer division, so a 500µs span reads as 0ms. That matches how people usually mean `duration_ms > 100` ("at least 100ms"). Fractional ms would need a float cast — happy to switch if preferred.
- Filters on `duration_ms` don't use the `(service_name, duration_ns DESC)` index because they're predicate-on-expression. Percentile/ordering are already full scans of the grouped rows, so no index loss there.

## Test plan

- [x] New unit test `TestBuild_DurationMSField` covering select/where/order_by
- [x] `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)