### PR TITLE
feat(ui): linear scroll-driven accordion collapse

### DIFF
--- a/ui/src/components/ui/Accordion.tsx
+++ b/ui/src/components/ui/Accordion.tsx
@@ -6,22 +6,36 @@ interface Props {
   open: boolean;
   onToggle: () => void;
   children: React.ReactNode;
-  /** Optional compact summary shown on the header bar — typically only
-   *  rendered when the accordion is collapsed, so the user can see the
+  /** Optional compact summary shown on the header bar — rendered when the
+   *  accordion is collapsed (manually or by scroll) so the user can see the
    *  key state without expanding. */
   collapsedSummary?: React.ReactNode;
+  /** Scroll-driven collapse progress in [0, 1]. 0 = fully open, 1 = fully
+   *  collapsed from scroll. Combined with `open`: the effective openness is
+   *  `open ? (1 - collapseProgress) : 0`, so a scroll-collapsed accordion
+   *  will re-expand as the user scrolls back to the top, but a user-closed
+   *  accordion stays closed. Defaults to 0 (no scroll effect). */
+  collapseProgress?: number;
 }
 
 // A single accordion — clickable header bar plus a collapsible body. The
-// body uses grid-template-rows 0fr→1fr so the content height animates
-// without having to know its measured height.
+// body uses `grid-template-rows: Nfr` where N ∈ [0, 1] so the content
+// height scales linearly between 0 (collapsed) and its intrinsic size
+// (fully open), and we can interpolate smoothly from scroll.
 export function Accordion({
   label,
   open,
   onToggle,
   children,
   collapsedSummary,
+  collapseProgress = 0,
 }: Props) {
+  const clamped = Math.max(0, Math.min(1, collapseProgress));
+  const openness = open ? 1 - clamped : 0;
+  // Show the collapsed summary once we're mostly shut — the content
+  // underneath is effectively invisible by then, so the header text is the
+  // only way to tell what the accordion holds.
+  const lookCollapsed = openness < 0.1;
   return (
     <div className="border-b" style={{ borderColor: "var(--color-border)" }}>
       <button
@@ -32,23 +46,28 @@ export function Accordion({
           "hover:bg-[var(--color-surface-muted)]",
         )}
         style={{ color: "var(--color-ink-muted)" }}
-        aria-expanded={open}
+        aria-expanded={!lookCollapsed}
       >
-        {open ? (
-          <ChevronDown className="w-3.5 h-3.5" />
-        ) : (
+        {lookCollapsed ? (
           <ChevronRight className="w-3.5 h-3.5" />
+        ) : (
+          <ChevronDown className="w-3.5 h-3.5" />
         )}
         <span className="uppercase tracking-wide">{label}</span>
-        {!open && collapsedSummary ? (
+        {lookCollapsed && collapsedSummary ? (
           <span className="ml-2 normal-case tracking-normal truncate">
             {collapsedSummary}
           </span>
         ) : null}
       </button>
       <div
-        className="grid transition-[grid-template-rows] duration-150 ease-out"
-        style={{ gridTemplateRows: open ? "1fr" : "0fr" }}
+        className="grid"
+        style={{
+          gridTemplateRows: `${openness}fr`,
+          // Short transition smooths a manual click (0→1 or 1→0) but stays
+          // quick enough that scroll-driven updates don't lag visibly.
+          transition: "grid-template-rows 80ms linear",
+        }}
       >
         <div className="overflow-hidden">{children}</div>
       </div>

--- a/ui/src/features/query/QueryChart.tsx
+++ b/ui/src/features/query/QueryChart.tsx
@@ -55,7 +55,7 @@ export function QueryChart({
   result,
   loading,
   error,
-  height = 220,
+  height = 125,
   bucketMs,
   fromMs,
   toMs,

--- a/ui/src/routes/LogsPage.tsx
+++ b/ui/src/routes/LogsPage.tsx
@@ -116,8 +116,7 @@ export function LogsPage() {
       <Accordion
         label="Chart"
         open={chartOpen}
-        collapseProgress={scrollProgress}
-        onToggle={() => (chartOpen ? setChartOpen(false) : reopen(setChartOpen))}
+        onToggle={() => setChartOpen((o) => !o)}
       >
         <div className="p-3" style={{ background: "var(--color-surface-muted)" }}>
           <QueryChart

--- a/ui/src/routes/LogsPage.tsx
+++ b/ui/src/routes/LogsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { Accordion } from "../components/ui/Accordion";
@@ -14,37 +14,59 @@ import {
 } from "../lib/query";
 import { logsRoute } from "../router";
 
-// Hysteresis thresholds for the scroll-driven accordion collapse. Collapse
-// once the user is clearly scrolling (>120px); expand only when they're
-// back near the top (<20px). The gap keeps the accordions from flickering
-// when you hover around the trigger point.
-const COLLAPSE_AT = 120;
-const EXPAND_AT = 20;
+// Scroll distance (in Explore-Data pixels) over which the query/chart
+// accordions collapse linearly from fully open to fully closed. Shorter
+// → more aggressive; longer → gentler.
+const COLLAPSE_DISTANCE = 220;
 
 export function LogsPage() {
   const search = logsRoute.useSearch();
   const navigate = useNavigate();
-  // Two accordions: the query builder and the chart. Both default open;
-  // either the user clicks to toggle, or scrolling Explore Data past the
-  // threshold collapses both, and scrolling back to the top reopens them.
+  // Two accordions: the query builder and the chart. Both default open.
+  // Click toggles the manual open/closed state; the scroll-driven progress
+  // below multiplies the effective openness when open, so a user who's
+  // scrolled halfway sees the accordion at half height.
   const [queryOpen, setQueryOpen] = useState(true);
   const [chartOpen, setChartOpen] = useState(true);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  const rafRef = useRef<number | null>(null);
 
   // Reset on tab change — Explore is the only tab whose scroll drives the
-  // collapse, so switching away should restore both accordions.
+  // collapse, so switching away should restore both accordions and drop
+  // any in-flight progress.
   useEffect(() => {
     setQueryOpen(true);
     setChartOpen(true);
+    setScrollProgress(0);
   }, [search.tab]);
 
+  // Clean up any queued rAF on unmount.
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
+
   const handleExploreScrollY = (y: number) => {
-    if (y > COLLAPSE_AT) {
-      setQueryOpen((o) => (o ? false : o));
-      setChartOpen((o) => (o ? false : o));
-    } else if (y < EXPAND_AT) {
-      setQueryOpen((o) => (o ? o : true));
-      setChartOpen((o) => (o ? o : true));
-    }
+    // Coalesce rapid scroll events into at most one setState per frame —
+    // otherwise a single physical scroll fires ~10 setStates and thrashes
+    // the React tree unnecessarily.
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const p = Math.max(0, Math.min(1, y / COLLAPSE_DISTANCE));
+      setScrollProgress((prev) => (prev === p ? prev : p));
+    });
+  };
+
+  const reopen = (set: (v: boolean) => void) => {
+    // Clicking to open a scroll-collapsed accordion is useless if scroll
+    // progress stays at 1 — the multiplier would pin openness at 0. Reset
+    // progress so the click actually reveals content; the next real scroll
+    // event will re-collapse proportionally.
+    setScrollProgress(0);
+    set(true);
   };
 
   const setSearch = (next: QuerySearch) =>
@@ -79,7 +101,8 @@ export function LogsPage() {
       <Accordion
         label="Query"
         open={queryOpen}
-        onToggle={() => setQueryOpen((o) => !o)}
+        collapseProgress={scrollProgress}
+        onToggle={() => (queryOpen ? setQueryOpen(false) : reopen(setQueryOpen))}
         collapsedSummary={querySummary(search)}
       >
         <DefinePanel
@@ -93,7 +116,8 @@ export function LogsPage() {
       <Accordion
         label="Chart"
         open={chartOpen}
-        onToggle={() => setChartOpen((o) => !o)}
+        collapseProgress={scrollProgress}
+        onToggle={() => (chartOpen ? setChartOpen(false) : reopen(setChartOpen))}
       >
         <div className="p-3" style={{ background: "var(--color-surface-muted)" }}>
           <QueryChart

--- a/ui/src/routes/TracesPage.tsx
+++ b/ui/src/routes/TracesPage.tsx
@@ -100,8 +100,7 @@ export function TracesPage() {
       <Accordion
         label="Chart"
         open={chartOpen}
-        collapseProgress={scrollProgress}
-        onToggle={() => (chartOpen ? setChartOpen(false) : reopen(setChartOpen))}
+        onToggle={() => setChartOpen((o) => !o)}
       >
         <div className="p-3" style={{ background: "var(--color-surface-muted)" }}>
           <QueryChart

--- a/ui/src/routes/TracesPage.tsx
+++ b/ui/src/routes/TracesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { Accordion } from "../components/ui/Accordion";
@@ -14,29 +14,42 @@ import {
 } from "../lib/query";
 import { tracesRoute } from "../router";
 
-// See LogsPage — same scroll-driven collapse, shared thresholds.
-const COLLAPSE_AT = 120;
-const EXPAND_AT = 20;
+// See LogsPage — scroll distance over which the accordions collapse.
+const COLLAPSE_DISTANCE = 220;
 
 export function TracesPage() {
   const search = tracesRoute.useSearch();
   const navigate = useNavigate();
   const [queryOpen, setQueryOpen] = useState(true);
   const [chartOpen, setChartOpen] = useState(true);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
     setQueryOpen(true);
     setChartOpen(true);
+    setScrollProgress(0);
   }, [search.tab]);
 
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
+
   const handleExploreScrollY = (y: number) => {
-    if (y > COLLAPSE_AT) {
-      setQueryOpen((o) => (o ? false : o));
-      setChartOpen((o) => (o ? false : o));
-    } else if (y < EXPAND_AT) {
-      setQueryOpen((o) => (o ? o : true));
-      setChartOpen((o) => (o ? o : true));
-    }
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const p = Math.max(0, Math.min(1, y / COLLAPSE_DISTANCE));
+      setScrollProgress((prev) => (prev === p ? prev : p));
+    });
+  };
+
+  const reopen = (set: (v: boolean) => void) => {
+    setScrollProgress(0);
+    set(true);
   };
 
   const setSearch = (next: QuerySearch) =>
@@ -72,7 +85,8 @@ export function TracesPage() {
       <Accordion
         label="Query"
         open={queryOpen}
-        onToggle={() => setQueryOpen((o) => !o)}
+        collapseProgress={scrollProgress}
+        onToggle={() => (queryOpen ? setQueryOpen(false) : reopen(setQueryOpen))}
         collapsedSummary={querySummary(search)}
       >
         <DefinePanel
@@ -86,7 +100,8 @@ export function TracesPage() {
       <Accordion
         label="Chart"
         open={chartOpen}
-        onToggle={() => setChartOpen((o) => !o)}
+        collapseProgress={scrollProgress}
+        onToggle={() => (chartOpen ? setChartOpen(false) : reopen(setChartOpen))}
       >
         <div className="p-3" style={{ background: "var(--color-surface-muted)" }}>
           <QueryChart


### PR DESCRIPTION
## Summary

Replaces the snap-at-threshold scroll collapse with a linear one. As the Explore Data table scrolls from 0 → ~220px, the query and chart accordions shrink smoothly from full height to zero instead of flipping open/closed at a boundary.

### How

- **Accordion** gains a `collapseProgress` prop (0..1). Effective openness is `open ? (1 - progress) : 0`, applied via `grid-template-rows: Nfr` so the row interpolates linearly with the scroll.
- **Pages** track a single `scrollProgress = clamp(y / 220, 0, 1)`, rAF-coalesced to at most one setState per frame so rapid scroll events don't thrash React.
- **Click behaviour** preserved: clicking a scroll-collapsed accordion resets progress to 0 so the click actually reveals content; the next real scroll event re-collapses proportionally.
- Short transition (80ms linear) still smooths the click toggle but is fast enough that scroll updates don't visibly lag.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [ ] Manual: scroll Explore Data tab on /logs and /traces; confirm collapse tracks scroll position proportionally, no flicker at the hysteresis band (since there is none now), click-to-reopen still works after scrolling down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)