### PR TITLE
feat(ui+loadgen): log attribute panel and trace↔log correlation

### DIFF
--- a/cmd/loadgen/main.go
+++ b/cmd/loadgen/main.go
@@ -91,27 +91,25 @@ func main() {
 	}()
 
 	// Log providers, one per unique service — mirrors the tracer setup so
-	// log records carry the right service.name resource. Built across the
-	// same service set as traces so a combined run produces a coherent
-	// service catalog.
+	// log records carry the right service.name resource. Always built
+	// (even when --logs-rate is 0) because trace templates can emit
+	// correlation logs inside their own span context, independent of the
+	// background log-only emission loop.
 	logTemplates := filterLogTemplates(allLogs, *servicesFlag)
-	var logProviders map[string]*sdklog.LoggerProvider
-	if *logsRate > 0 {
-		if len(logTemplates) == 0 {
-			log.Fatalf("no log templates matched --services=%q", *servicesFlag)
-		}
-		logProviders, err = buildLogProviders(logTemplates, *endpoint, *insecure)
-		if err != nil {
-			log.Fatalf("build log providers: %v", err)
-		}
-		defer func() {
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			for _, lp := range logProviders {
-				_ = lp.Shutdown(shutdownCtx)
-			}
-		}()
+	if *logsRate > 0 && len(logTemplates) == 0 {
+		log.Fatalf("no log templates matched --services=%q", *servicesFlag)
 	}
+	logProviders, err := buildLogProvidersForServices(templates, *endpoint, *insecure)
+	if err != nil {
+		log.Fatalf("build log providers: %v", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		for _, lp := range logProviders {
+			_ = lp.Shutdown(shutdownCtx)
+		}
+	}()
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -141,6 +139,10 @@ func main() {
 	for svc, p := range providers {
 		tracers[svc] = p.Tracer("loadgen")
 	}
+	loggers := Loggers{}
+	for svc, p := range logProviders {
+		loggers[svc] = p.Logger("loadgen")
+	}
 
 	tokens := make(chan struct{}, *parallelism)
 	var wg sync.WaitGroup
@@ -150,7 +152,7 @@ func main() {
 			defer wg.Done()
 			for range tokens {
 				tpl := templates[rand.IntN(len(templates))]
-				if err := tpl.Emit(ctx, tracers); err != nil {
+				if err := tpl.Emit(ctx, tracers, loggers); err != nil {
 					failed.Add(1)
 					continue
 				}
@@ -183,10 +185,6 @@ func main() {
 	// plenty because each emit is just a record append to the batch
 	// processor.
 	if *logsRate > 0 {
-		loggers := Loggers{}
-		for svc, p := range logProviders {
-			loggers[svc] = p.Logger("loadgen")
-		}
 		logPeriod := time.Duration(float64(time.Second) / *logsRate)
 		go func() {
 			for {
@@ -227,7 +225,12 @@ func jitterDuration(base time.Duration, jitter float64) time.Duration {
 	return time.Duration(float64(base) * factor)
 }
 
-func buildLogProviders(tpls []LogTemplate, endpoint string, insecure bool) (map[string]*sdklog.LoggerProvider, error) {
+// buildLogProvidersForServices builds one LoggerProvider per trace-template
+// service so trace templates can emit correlation logs under the right
+// service.name resource. Using trace templates (not log templates) as the
+// service set ensures every service that can emit a span can also emit a
+// log — independent of whether the log-only background loop is active.
+func buildLogProvidersForServices(tpls []TraceTemplate, endpoint string, insecure bool) (map[string]*sdklog.LoggerProvider, error) {
 	byService := map[string]*sdklog.LoggerProvider{}
 	services := map[string]struct{}{}
 	for _, t := range tpls {

--- a/cmd/loadgen/templates.go
+++ b/cmd/loadgen/templates.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -22,7 +23,7 @@ type Tracers map[string]trace.Tracer
 type TraceTemplate struct {
 	Service     string
 	Description string
-	Emit        func(ctx context.Context, tracers Tracers) error
+	Emit        func(ctx context.Context, tracers Tracers, loggers Loggers) error
 }
 
 var allTemplates = []TraceTemplate{
@@ -102,7 +103,7 @@ var allTemplates = []TraceTemplate{
 // Template implementations
 // -----------------------------------------------------------------------------
 
-func emitHTTPGetSuccess(ctx context.Context, tracers Tracers) error {
+func emitHTTPGetSuccess(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["api-gateway"]
 	route := pickRoute()
 	ctx, root := tracer.Start(ctx, "GET "+route, trace.WithSpanKind(trace.SpanKindServer))
@@ -153,7 +154,7 @@ func emitHTTPGetSuccess(ctx context.Context, tracers Tracers) error {
 	return nil
 }
 
-func emitHTTPPostValidationError(ctx context.Context, tracers Tracers) error {
+func emitHTTPPostValidationError(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["api-gateway"]
 	ctx, root := tracer.Start(ctx, "POST /orders", trace.WithSpanKind(trace.SpanKindServer))
 	root.SetAttributes(
@@ -178,7 +179,7 @@ func emitHTTPPostValidationError(ctx context.Context, tracers Tracers) error {
 	return nil
 }
 
-func emitHTTPServerError(ctx context.Context, tracers Tracers) error {
+func emitHTTPServerError(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["api-gateway"]
 	ctx, root := tracer.Start(ctx, "GET /reports", trace.WithSpanKind(trace.SpanKindServer))
 	root.SetAttributes(
@@ -193,18 +194,28 @@ func emitHTTPServerError(ctx context.Context, tracers Tracers) error {
 
 	sleepLike(10*time.Millisecond, 5*time.Millisecond)
 
-	_, dep := tracer.Start(ctx, "call reporting-service")
+	depCtx, dep := tracer.Start(ctx, "call reporting-service")
 	dep.SetAttributes(
 		attribute.String("rpc.service", "ReportingService"),
 		attribute.String("rpc.method", "GenerateMonthly"),
 	)
 	dep.SetStatus(codes.Error, "connection refused")
 	sleepLike(50*time.Millisecond, 20*time.Millisecond)
+	// Emit a correlated ERROR log inside the dep span's context — the SDK
+	// stamps trace_id + span_id from ctx so the log row links back to this
+	// span.
+	if logger := loggers["api-gateway"]; logger != nil {
+		emit(depCtx, logger, log.SeverityError, "ERROR",
+			"reporting-service unreachable: connection refused",
+			log.String("rpc.service", "ReportingService"),
+			log.Int("http.response.status_code", 500),
+		)
+	}
 	dep.End()
 	return nil
 }
 
-func emitSlowCheckout(ctx context.Context, tracers Tracers) error {
+func emitSlowCheckout(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	// Cross-service slow trace. api-gateway receives, then fans out to
 	// the owning services — inventory on api-gateway (simulating a
 	// monolith module), payments on the payments service, and
@@ -248,7 +259,7 @@ func emitSlowCheckout(ctx context.Context, tracers Tracers) error {
 	return nil
 }
 
-func emitPaymentsAuthorize(ctx context.Context, tracers Tracers) error {
+func emitPaymentsAuthorize(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["payments"]
 	ctx, root := tracer.Start(ctx, "PaymentService/Authorize", trace.WithSpanKind(trace.SpanKindServer))
 	root.SetAttributes(
@@ -298,7 +309,7 @@ func emitPaymentsAuthorize(ctx context.Context, tracers Tracers) error {
 	return nil
 }
 
-func emitPaymentsRefund(ctx context.Context, tracers Tracers) error {
+func emitPaymentsRefund(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	// Refund spans the payments service plus a db-worker DB hop — gives a
 	// two-service trace that's easy to scan in the summary swim-lane.
 	pay := tracers["payments"]
@@ -326,7 +337,7 @@ func emitPaymentsRefund(ctx context.Context, tracers Tracers) error {
 	return nil
 }
 
-func emitDBQuery(ctx context.Context, tracers Tracers) error {
+func emitDBQuery(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["db-worker"]
 	systems := []string{"postgresql", "redis", "mysql"}
 	sys := systems[rand.IntN(len(systems))]
@@ -348,7 +359,7 @@ func emitDBQuery(ctx context.Context, tracers Tracers) error {
 // records as an exception event without upgrading the span status. This is
 // the interesting case: status is UNSET but `error = true` still fires via
 // the exception-event branch of the synthetic field.
-func emitTimeoutException(ctx context.Context, tracers Tracers) error {
+func emitTimeoutException(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["api-gateway"]
 	ctx, root := tracer.Start(ctx, "GET /slow-api", trace.WithSpanKind(trace.SpanKindServer))
 	root.SetAttributes(
@@ -382,9 +393,9 @@ func emitTimeoutException(ctx context.Context, tracers Tracers) error {
 // emitPaymentsPanic models an unhandled error with both an exception event
 // and ERROR status — belt and braces, matches what well-instrumented code
 // emits via OTel's RecordError helper.
-func emitPaymentsPanic(ctx context.Context, tracers Tracers) error {
+func emitPaymentsPanic(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["payments"]
-	_, span := tracer.Start(ctx, "PaymentService/Charge", trace.WithSpanKind(trace.SpanKindServer))
+	spanCtx, span := tracer.Start(ctx, "PaymentService/Charge", trace.WithSpanKind(trace.SpanKindServer))
 	span.SetAttributes(
 		attribute.String("rpc.service", "PaymentService"),
 		attribute.String("rpc.method", "Charge"),
@@ -399,6 +410,16 @@ func emitPaymentsPanic(ctx context.Context, tracers Tracers) error {
 				"  at grpc.Dispatch (Dispatch.java:55)"),
 	))
 	span.SetStatus(codes.Error, "nil pointer dereference")
+	// Correlated ERROR log — this is what the structured logger emits right
+	// before/after an exception in real instrumented code.
+	if logger := loggers["payments"]; logger != nil {
+		emit(spanCtx, logger, log.SeverityError, "ERROR",
+			"nil pointer dereference: payment.card was nil",
+			log.String("exception.type", "NullPointerException"),
+			log.String("rpc.service", "PaymentService"),
+			log.String("rpc.method", "Charge"),
+		)
+	}
 	sleepLike(5*time.Millisecond, 2*time.Millisecond)
 	span.End()
 	return nil
@@ -411,7 +432,7 @@ func emitPaymentsPanic(ctx context.Context, tracers Tracers) error {
 // boundary looks like in OTel — you can't use parent/child because the
 // consumer runs async with a different wall-clock start, so Links are the
 // right mechanism.
-func emitAsyncLinkedJob(ctx context.Context, tracers Tracers) error {
+func emitAsyncLinkedJob(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["notifications"]
 	// 1) Producer trace: enqueue.
 	producerCtx, producer := tracer.Start(ctx, "queue.publish",
@@ -462,7 +483,7 @@ func emitAsyncLinkedJob(ctx context.Context, tracers Tracers) error {
 // render a dense ladder of tick marks on a single bar, and gives queries
 // something interesting to count (`SELECT count() WHERE event.name =
 // 'item.processed'` once we have event-level datasets).
-func emitBatchProcess(ctx context.Context, tracers Tracers) error {
+func emitBatchProcess(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["db-worker"]
 	_, span := tracer.Start(ctx, "batch.process",
 		trace.WithSpanKind(trace.SpanKindInternal))
@@ -509,9 +530,9 @@ func emitBatchProcess(ctx context.Context, tracers Tracers) error {
 // latter recording an exception event too (but keeping the client span
 // itself OK — retry exhaustion is a business outcome, not a span-level
 // bug). Great for seeing event ticks spaced out along a single bar.
-func emitRetryingRequest(ctx context.Context, tracers Tracers) error {
+func emitRetryingRequest(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["api-gateway"]
-	_, span := tracer.Start(ctx, "http.client.request",
+	spanCtx, span := tracer.Start(ctx, "http.client.request",
 		trace.WithSpanKind(trace.SpanKindClient))
 	span.SetAttributes(
 		attribute.String("http.request.method", "POST"),
@@ -563,10 +584,21 @@ func emitRetryingRequest(ctx context.Context, tracers Tracers) error {
 		attribute.String("exception.message", "partner-webhook rejected after max retries"),
 	))
 	span.SetAttributes(attribute.Int("http.response.status_code", 503))
+	// Correlated WARN — retry exhaustion is worth surfacing in logs so the
+	// user can find the trace from the log stream. Trace/span IDs flow from
+	// spanCtx automatically.
+	if logger := loggers["api-gateway"]; logger != nil {
+		emit(spanCtx, logger, log.SeverityWarn, "WARN",
+			fmt.Sprintf("partner-webhook giving up after %d attempts", maxAttempts),
+			log.String("peer.service", "partner-webhook"),
+			log.Int("retry.attempts", maxAttempts),
+			log.String("error.kind", "retry_exhausted"),
+		)
+	}
 	return nil
 }
 
-func emitNotificationSend(ctx context.Context, tracers Tracers) error {
+func emitNotificationSend(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	tracer := tracers["notifications"]
 	ctx, root := tracer.Start(ctx, "email.send", trace.WithSpanKind(trace.SpanKindServer))
 	root.SetAttributes(
@@ -617,7 +649,7 @@ func emitNotificationSend(ctx context.Context, tracers Tracers) error {
 //	  analytics.emit               [api-gateway]
 //	    db.INSERT analytics        [db-worker]
 //	  response.serialize           [api-gateway]
-func emitBigCheckoutFlow(ctx context.Context, tracers Tracers) error {
+func emitBigCheckoutFlow(ctx context.Context, tracers Tracers, loggers Loggers) error {
 	api := tracers["api-gateway"]
 	pay := tracers["payments"]
 	notif := tracers["notifications"]

--- a/ui/src/components/ui/AttributesPanel.tsx
+++ b/ui/src/components/ui/AttributesPanel.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Filter as FilterIcon, Search } from "lucide-react";
+import type { Filter } from "../../lib/query";
+
+export interface AttrRow {
+  key: string;
+  value: unknown;
+  type: string;
+}
+
+interface Props {
+  /** Pre-built rows. Use when the caller has already merged multiple
+   *  sources (e.g. span meta + resource + attrs). */
+  rows?: AttrRow[];
+  /** Raw JSON string — parsed and sorted alphabetically. Use when the
+   *  caller just has the backend-supplied attributes blob. */
+  attributesJson?: string;
+  /** Placeholder for the filter input. */
+  filterPlaceholder?: string;
+  /**
+   * Where clicking the filter button on a scalar row navigates to. The
+   * query builder's URL schema is shared across /traces and /logs, so the
+   * dataset-appropriate route is the caller's choice. Defaults to /traces.
+   */
+  filterTarget?: "/traces" | "/logs";
+}
+
+/**
+ * Flat, filterable list of key-value attributes. Shared between the span
+ * detail panel and the logs Explore-Data row expander so both surfaces
+ * show structured data in a consistent way. Scalar rows get a
+ * hover-reveal filter button that jumps to the query builder with an
+ * equality filter on that field — parity with Honeycomb's "click to
+ * filter" workflow.
+ */
+export function AttributesPanel({
+  rows,
+  attributesJson,
+  filterPlaceholder = "Filter fields and values",
+  filterTarget = "/traces",
+}: Props) {
+  const navigate = useNavigate();
+  const [filter, setFilter] = useState("");
+
+  const allRows = rows ?? parseAttributes(attributesJson ?? "{}");
+
+  const applyFilter = (row: AttrRow) => {
+    const value = filterableValue(row);
+    if (value === null) return;
+    const f: Filter = { field: row.key, op: "=", value };
+    navigate({
+      to: filterTarget,
+      search: { where: [f] } as unknown as Record<string, unknown>,
+    });
+  };
+
+  const f = filter.toLowerCase();
+  const filtered =
+    f === ""
+      ? allRows
+      : allRows.filter(
+          (r) =>
+            r.key.toLowerCase().includes(f) ||
+            String(r.value).toLowerCase().includes(f),
+        );
+
+  return (
+    <div className="p-3 flex flex-col gap-3">
+      <div
+        className="flex items-center gap-2 px-2 py-1 rounded border sticky top-0"
+        style={{
+          borderColor: "var(--color-border)",
+          background: "var(--color-surface)",
+        }}
+      >
+        <Search className="w-3.5 h-3.5" style={{ color: "var(--color-ink-muted)" }} />
+        <input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder={filterPlaceholder}
+          className="bg-transparent outline-none text-sm flex-1"
+        />
+      </div>
+      <div className="flex flex-col">
+        {filtered.map((r) => {
+          const canFilter = filterableValue(r) !== null;
+          return (
+            <div
+              key={r.key}
+              className="group flex flex-col gap-0.5 py-2 border-b"
+              style={{ borderColor: "var(--color-border)" }}
+            >
+              <div className="flex items-center gap-1">
+                <TypePill type={r.type} />
+                <span
+                  className="text-xs font-mono truncate"
+                  style={{ color: "var(--color-ink-muted)" }}
+                >
+                  {r.key}
+                </span>
+                {canFilter && (
+                  <button
+                    type="button"
+                    onClick={() => applyFilter(r)}
+                    className="ml-auto opacity-0 group-hover:opacity-100 shrink-0 p-1 rounded hover:bg-[var(--color-surface-muted)]"
+                    title={`Filter ${filterTarget} to ${r.key} = ${String(r.value)}`}
+                  >
+                    <FilterIcon
+                      className="w-3 h-3"
+                      style={{ color: "var(--color-accent)" }}
+                    />
+                  </button>
+                )}
+              </div>
+              <div className="text-xs font-mono break-all">
+                {formatValue(r.value)}
+              </div>
+            </div>
+          );
+        })}
+        {filtered.length === 0 && (
+          <div
+            className="py-3 text-xs text-center"
+            style={{ color: "var(--color-ink-muted)" }}
+          >
+            No matching fields.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TypePill({ type }: { type: string }) {
+  return (
+    <span
+      className="inline-block text-[9px] uppercase tracking-wide mr-2 px-1 rounded"
+      style={{
+        background: "var(--color-surface-muted)",
+        color: "var(--color-ink-muted)",
+      }}
+    >
+      {type}
+    </span>
+  );
+}
+
+function filterableValue(row: AttrRow): string | number | boolean | null {
+  const v = row.value;
+  if (v === null || v === undefined) return null;
+  if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") return v;
+  return null;
+}
+
+/**
+ * Deterministic alphabetical sort. Case-insensitive codepoint comparison
+ * avoids the surprises of locale-aware sorts where "." and "_" can flip
+ * order depending on the user's Intl config.
+ */
+export function compareByKey(a: AttrRow, b: AttrRow): number {
+  const ka = a.key.toLowerCase();
+  const kb = b.key.toLowerCase();
+  if (ka < kb) return -1;
+  if (ka > kb) return 1;
+  return 0;
+}
+
+export function parseAttributes(json: string): AttrRow[] {
+  if (!json || json === "{}") return [];
+  try {
+    const obj = JSON.parse(json) as Record<string, unknown>;
+    return Object.entries(obj)
+      .map(([key, value]) => ({ key, value, type: detectType(value) }))
+      .sort(compareByKey);
+  } catch {
+    return [];
+  }
+}
+
+export function detectType(v: unknown): string {
+  if (v === null || v === undefined) return "null";
+  if (Array.isArray(v)) return "arr";
+  if (typeof v === "object") return "kv";
+  if (typeof v === "boolean") return "bool";
+  if (typeof v === "number") return Number.isInteger(v) ? "int" : "flt";
+  return "str";
+}
+
+export function formatValue(v: unknown): string {
+  if (v === null || v === undefined) return "—";
+  if (typeof v === "string") return v;
+  return JSON.stringify(v, null, 2);
+}

--- a/ui/src/features/query/EventsTable.tsx
+++ b/ui/src/features/query/EventsTable.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import type {
   Dataset,
   QueryResult,
@@ -8,6 +10,7 @@ import type {
 import { resolveSearchRange, runQuery } from "../../lib/query";
 import { formatDuration } from "../../lib/format";
 import { CopyButton } from "../../components/ui/CopyButton";
+import { AttributesPanel } from "../../components/ui/AttributesPanel";
 
 interface Props {
   dataset: Dataset;
@@ -167,6 +170,17 @@ function LogsTable({
   onScrollY?: (y: number) => void;
 }) {
   const idx = columnIndex(result);
+  // Track which rows the user has expanded. Keyed by row index into the
+  // current result set — swapping datasets or re-running the query
+  // remounts the component so we don't need a stable row key.
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set());
+  const toggle = (i: number) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(i) ? next.delete(i) : next.add(i);
+      return next;
+    });
+
   return (
     <div
       className="h-full overflow-auto font-mono text-xs leading-5"
@@ -178,6 +192,7 @@ function LogsTable({
           style={{ background: "var(--color-surface)", color: "var(--color-ink-muted)" }}
         >
           <tr>
+            <Th>{/* chevron column */}</Th>
             <Th>Time</Th>
             <Th>Severity</Th>
             <Th>Body</Th>
@@ -191,38 +206,101 @@ function LogsTable({
             const severityNum = Number(row[idx.severity_number] ?? 0);
             const body = String(row[idx.body] ?? "");
             const traceID = String(row[idx.trace_id] ?? "").toLowerCase();
+            const attributes = String(row[idx.attributes] ?? "{}");
+            const isOpen = expanded.has(i);
             return (
-              <tr key={i} className="align-top">
-                <Td muted className="whitespace-nowrap">
-                  {formatWall(timeNS)}
-                </Td>
-                <Td style={{ color: severityColor(severityNum) }}>
-                  {severityText || severityName(severityNum)}
-                </Td>
-                <Td className="whitespace-pre-wrap break-all">{body}</Td>
-                <Td>
-                  {traceID ? (
-                    <span className="inline-flex items-center gap-1">
-                      <Link
-                        to="/traces/$traceId"
-                        params={{ traceId: traceID }}
-                        className="underline"
-                        style={{ color: "var(--color-accent)" }}
-                      >
-                        {traceID.slice(0, 8)}
-                      </Link>
-                      <CopyButton value={traceID} label="Copy trace ID" />
-                    </span>
-                  ) : (
-                    <span style={{ color: "var(--color-ink-muted)" }}>·</span>
-                  )}
-                </Td>
-              </tr>
+              <FragmentRow
+                key={i}
+                isOpen={isOpen}
+                onToggle={() => toggle(i)}
+                time={formatWall(timeNS)}
+                severityText={severityText || severityName(severityNum)}
+                severityColor={severityColor(severityNum)}
+                body={body}
+                traceID={traceID}
+                attributesJson={attributes}
+              />
             );
           })}
         </tbody>
       </table>
     </div>
+  );
+}
+
+function FragmentRow({
+  isOpen,
+  onToggle,
+  time,
+  severityText,
+  severityColor,
+  body,
+  traceID,
+  attributesJson,
+}: {
+  isOpen: boolean;
+  onToggle: () => void;
+  time: string;
+  severityText: string;
+  severityColor: string;
+  body: string;
+  traceID: string;
+  attributesJson: string;
+}) {
+  return (
+    <>
+      <tr
+        className="align-top cursor-pointer hover:bg-[var(--color-surface-muted)]"
+        onClick={onToggle}
+      >
+        <Td className="w-6">
+          {isOpen ? (
+            <ChevronDown className="w-3.5 h-3.5" />
+          ) : (
+            <ChevronRight className="w-3.5 h-3.5" />
+          )}
+        </Td>
+        <Td muted className="whitespace-nowrap">
+          {time}
+        </Td>
+        <Td style={{ color: severityColor }}>{severityText}</Td>
+        <Td className="whitespace-pre-wrap break-all">{body}</Td>
+        <Td onClick={(e) => e.stopPropagation()}>
+          {traceID ? (
+            <span className="inline-flex items-center gap-1">
+              <Link
+                to="/traces/$traceId"
+                params={{ traceId: traceID }}
+                className="underline"
+                style={{ color: "var(--color-accent)" }}
+              >
+                {traceID.slice(0, 8)}
+              </Link>
+              <CopyButton value={traceID} label="Copy trace ID" />
+            </span>
+          ) : (
+            <span style={{ color: "var(--color-ink-muted)" }}>·</span>
+          )}
+        </Td>
+      </tr>
+      {isOpen && (
+        <tr>
+          <td
+            colSpan={5}
+            className="border-b"
+            style={{
+              background: "var(--color-surface-muted)",
+              borderColor: "var(--color-border)",
+            }}
+          >
+            <AttributesPanel
+              attributesJson={attributesJson}
+              filterTarget="/logs"
+            />
+          </td>
+        </tr>
+      )}
+    </>
   );
 }
 
@@ -264,7 +342,7 @@ function severityColor(n: number): string {
   return "var(--color-ink-muted)";
 }
 
-function Th({ children }: { children: React.ReactNode }) {
+function Th({ children }: { children?: React.ReactNode }) {
   return (
     <th
       className="px-4 py-2 border-b font-medium uppercase tracking-wide"
@@ -280,11 +358,13 @@ function Td({
   className,
   style,
   muted,
+  onClick,
 }: {
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
   muted?: boolean;
+  onClick?: React.MouseEventHandler<HTMLTableCellElement>;
 }) {
   return (
     <td
@@ -294,6 +374,7 @@ function Td({
         color: muted ? "var(--color-ink-muted)" : undefined,
         ...style,
       }}
+      onClick={onClick}
     >
       {children}
     </td>

--- a/ui/src/features/traces/SpanDetail.tsx
+++ b/ui/src/features/traces/SpanDetail.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
 import * as Tabs from "@radix-ui/react-tabs";
-import { Link, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft, ExternalLink, Filter as FilterIcon, Search } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft, ExternalLink } from "lucide-react";
 import type { SpanOut, TraceDetail, TraceResource } from "../../lib/api";
-import type { Filter } from "../../lib/query";
 import { serviceColor } from "../../lib/colors";
 import { formatDuration } from "../../lib/format";
 import { spanStatusLabel } from "./tree";
 import { CopyButton } from "../../components/ui/CopyButton";
+import {
+  AttributesPanel,
+  compareByKey,
+  detectType,
+  formatValue,
+  parseAttributes,
+  type AttrRow,
+} from "../../components/ui/AttributesPanel";
 
 interface Props {
   span: SpanOut | null;
@@ -85,7 +92,7 @@ export function SpanDetail({
           <Tab value="links">Links ({span.links?.length ?? 0})</Tab>
         </Tabs.List>
         <Tabs.Content value="fields" className="flex-1 overflow-auto">
-          <FieldsTab rows={allFields} />
+          <AttributesPanel rows={allFields} />
         </Tabs.Content>
         <Tabs.Content value="events" className="flex-1 overflow-auto">
           <EventsTab
@@ -196,128 +203,6 @@ function Header({ span }: { span: SpanOut }) {
         )}
       </div>
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Fields tab
-// ---------------------------------------------------------------------------
-
-function FieldsTab({ rows }: { rows: AttrRow[] }) {
-  const navigate = useNavigate();
-  const [filter, setFilter] = useState("");
-
-  // Click a value → navigate to /traces with a new equality filter on that
-  // field. Only makes sense for scalar values; arrays/kvs skip the button.
-  const applyFilter = (row: AttrRow) => {
-    const value = filterableValue(row);
-    if (value === null) return;
-    const f: Filter = { field: row.key, op: "=", value };
-    navigate({
-      to: "/traces",
-      search: { where: [f] } as unknown as Record<string, unknown>,
-    });
-  };
-  const f = filter.toLowerCase();
-  const filtered =
-    f === ""
-      ? rows
-      : rows.filter(
-          (r) =>
-            r.key.toLowerCase().includes(f) ||
-            String(r.value).toLowerCase().includes(f),
-        );
-
-  return (
-    <div className="p-3 flex flex-col gap-3">
-      <div
-        className="flex items-center gap-2 px-2 py-1 rounded border sticky top-0"
-        style={{
-          borderColor: "var(--color-border)",
-          background: "var(--color-surface)",
-        }}
-      >
-        <Search className="w-3.5 h-3.5" style={{ color: "var(--color-ink-muted)" }} />
-        <input
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          placeholder="Filter fields and values"
-          className="bg-transparent outline-none text-sm flex-1"
-        />
-      </div>
-      <div className="flex flex-col">
-        {filtered.map((r) => {
-          const canFilter = filterableValue(r) !== null;
-          return (
-            <div
-              key={r.key}
-              className="group flex flex-col gap-0.5 py-2 border-b"
-              style={{ borderColor: "var(--color-border)" }}
-            >
-              <div className="flex items-center gap-1">
-                <TypePill type={r.type} />
-                <span
-                  className="text-xs font-mono truncate"
-                  style={{ color: "var(--color-ink-muted)" }}
-                >
-                  {r.key}
-                </span>
-                {canFilter && (
-                  <button
-                    type="button"
-                    onClick={() => applyFilter(r)}
-                    className="ml-auto opacity-0 group-hover:opacity-100 shrink-0 p-1 rounded hover:bg-[var(--color-surface-muted)]"
-                    title={`Filter /traces to ${r.key} = ${String(r.value)}`}
-                  >
-                    <FilterIcon
-                      className="w-3 h-3"
-                      style={{ color: "var(--color-accent)" }}
-                    />
-                  </button>
-                )}
-              </div>
-              <div className="text-xs font-mono break-all">
-                {formatValue(r.value)}
-              </div>
-            </div>
-          );
-        })}
-        {filtered.length === 0 && (
-          <div
-            className="py-3 text-xs text-center"
-            style={{ color: "var(--color-ink-muted)" }}
-          >
-            No matching fields.
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/**
- * Returns the value we'd send on the filter's `value` field, or null when
- * the row isn't filterable. Arrays, objects, and nullish values are skipped
- * — the query engine can't express equality on those directly.
- */
-function filterableValue(row: AttrRow): string | number | boolean | null {
-  const v = row.value;
-  if (v === null || v === undefined) return null;
-  if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") return v;
-  return null;
-}
-
-function TypePill({ type }: { type: string }) {
-  return (
-    <span
-      className="inline-block text-[9px] uppercase tracking-wide mr-2 px-1 rounded"
-      style={{
-        background: "var(--color-surface-muted)",
-        color: "var(--color-ink-muted)",
-      }}
-    >
-      {type}
-    </span>
   );
 }
 
@@ -433,17 +318,6 @@ function EventDetail({
     return mergeAttrs(meta, parseAttributes(event.attributes));
   }, [event, span.start_ns]);
 
-  const [filter, setFilter] = useState("");
-  const f = filter.toLowerCase();
-  const filtered =
-    f === ""
-      ? rows
-      : rows.filter(
-          (r) =>
-            r.key.toLowerCase().includes(f) ||
-            String(r.value).toLowerCase().includes(f),
-        );
-
   return (
     <div className="flex flex-col h-full">
       <div
@@ -479,55 +353,8 @@ function EventDetail({
           </div>
         </div>
       </div>
-      <div className="p-3 flex flex-col gap-3 overflow-auto">
-        <div
-          className="flex items-center gap-2 px-2 py-1 rounded border"
-          style={{
-            borderColor: "var(--color-border)",
-            background: "var(--color-surface)",
-          }}
-        >
-          <Search
-            className="w-3.5 h-3.5"
-            style={{ color: "var(--color-ink-muted)" }}
-          />
-          <input
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter fields and values"
-            className="bg-transparent outline-none text-sm flex-1"
-          />
-        </div>
-        <div className="flex flex-col">
-          {filtered.map((r) => (
-            <div
-              key={r.key}
-              className="flex flex-col gap-0.5 py-2 border-b"
-              style={{ borderColor: "var(--color-border)" }}
-            >
-              <div className="flex items-center gap-1">
-                <TypePill type={r.type} />
-                <span
-                  className="text-xs font-mono truncate"
-                  style={{ color: "var(--color-ink-muted)" }}
-                >
-                  {r.key}
-                </span>
-              </div>
-              <div className="text-xs font-mono break-all">
-                {formatValue(r.value)}
-              </div>
-            </div>
-          ))}
-          {filtered.length === 0 && (
-            <div
-              className="py-3 text-xs text-center"
-              style={{ color: "var(--color-ink-muted)" }}
-            >
-              No matching fields.
-            </div>
-          )}
-        </div>
+      <div className="flex-1 overflow-auto">
+        <AttributesPanel rows={rows} />
       </div>
     </div>
   );
@@ -636,25 +463,6 @@ function Empty({ children }: { children: React.ReactNode }) {
   );
 }
 
-interface AttrRow {
-  key: string;
-  value: unknown;
-  type: string;
-}
-
-/**
- * Deterministic alphabetical sort. Case-insensitive codepoint comparison
- * avoids the surprises of locale-aware sorts where "." and "_" can flip
- * order depending on the user's Intl config.
- */
-function compareByKey(a: AttrRow, b: AttrRow): number {
-  const ka = a.key.toLowerCase();
-  const kb = b.key.toLowerCase();
-  if (ka < kb) return -1;
-  if (ka > kb) return 1;
-  return 0;
-}
-
 /**
  * Merge several AttrRow sources into a single key-sorted list. Dedupes by
  * key, with earlier arrays winning — so a span-meta `service.name`
@@ -668,18 +476,6 @@ function mergeAttrs(...sources: AttrRow[][]): AttrRow[] {
     }
   }
   return Array.from(seen.values()).sort(compareByKey);
-}
-
-function parseAttributes(json: string): AttrRow[] {
-  if (!json || json === "{}") return [];
-  try {
-    const obj = JSON.parse(json) as Record<string, unknown>;
-    return Object.entries(obj)
-      .map(([key, value]) => ({ key, value, type: detectType(value) }))
-      .sort(compareByKey);
-  } catch {
-    return [];
-  }
 }
 
 /**
@@ -766,17 +562,3 @@ function statusCodeName(code: number): string {
   }
 }
 
-function detectType(v: unknown): string {
-  if (v === null || v === undefined) return "null";
-  if (Array.isArray(v)) return "arr";
-  if (typeof v === "object") return "kv";
-  if (typeof v === "boolean") return "bool";
-  if (typeof v === "number") return Number.isInteger(v) ? "int" : "flt";
-  return "str";
-}
-
-function formatValue(v: unknown): string {
-  if (v === null || v === undefined) return "—";
-  if (typeof v === "string") return v;
-  return JSON.stringify(v, null, 2);
-}


### PR DESCRIPTION
## Summary

Two linked gaps on the logs page:

### 1. Log rows didn't show attributes

The OTel log record's structured attrs (`http.method`, `fraud.score`, …) came back from the backend but the UI never rendered them — you could see the body but not *why* the log fired.

- Extracted the span detail `FieldsTab` into a reusable `ui/src/components/ui/AttributesPanel.tsx`. Exports `parseAttributes`, `detectType`, `formatValue`, `compareByKey` so `SpanDetail.tsx` can reuse them for its span-meta + resource + attr merging.
- `SpanDetail.tsx` and its `EventDetail` drill-down both delegate to `AttributesPanel` — the span fields tab and event detail keep the same look they had before.
- `LogsTable` gains a leading chevron column. Row click toggles an inline detail row rendering `AttributesPanel` against the log's `attributes` JSON, with the same search box, type pills, and click-to-filter affordances as the span side. `filterTarget` switches to `/logs` so click-to-filter lands on the right dataset.

### 2. Trace column was dead weight

Loadgen emitted logs with no active span, so `trace_id` was always empty and the column just showed a middle dot. Fixed at the source:

- `TraceTemplate.Emit` signature widened to take a `Loggers` map alongside `Tracers`. Main loop threads loggers through every trace-template call.
- Log providers are now **always built**, not gated behind `--logs-rate`. OTLP log providers are cheap and always-on correlation matters more than the flag ergonomics.
- Three templates emit a log record inside their span ctx — the OTel SDK stamps `trace_id` + `span_id` from context automatically:
  - `emitHTTPServerError` → ERROR "reporting-service unreachable"
  - `emitPaymentsPanic` → ERROR "nil pointer dereference"
  - `emitRetryingRequest` → WARN "partner-webhook giving up after N attempts"

## Verification

- [x] `go vet ./...` + `go test ./...`
- [x] `cd ui && npx tsc --noEmit -p tsconfig.app.json`
- [x] Smoke: 154 traces emitted with `--rate 20 --logs-rate 0`; 9/200 recent logs returned populated `trace_id` + `span_id` pointing at the correct span.
- [ ] Visual: click a log row → attributes panel expands; click trace-id link on a correlated row → `/traces/$id` opens the waterfall with the logged span highlighted.

## Notes

- Extraction was also applied to `EventDetail` (the span-event drill-down). It loses its own inline filter renderer but gains the click-to-filter button behaviour for free — minor UX improvement.
- Uncorrelated logs (from the background `--logs-rate` loop) still render with the existing middle-dot placeholder, no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)