### PR TITLE
fix(store): ListFields returns nothing without a service + missing synthetic fields

### DIFF
--- a/internal/store/sqlite/queries.go
+++ b/internal/store/sqlite/queries.go
@@ -509,6 +509,20 @@ func (s *Store) ListFields(ctx context.Context, f store.FieldFilter) ([]store.Fi
 		return nil, errors.New("signal_type must be 'span' or 'log'")
 	}
 	limit := clampLimit(f.Limit, 100, 500)
+	// Start with the promoted / synthetic fields the query builder's
+	// realColumn() resolves natively (name, service.name, duration_ns,
+	// http.route, …). These aren't strictly required to be in
+	// attribute_keys — that table only tracks JSONB attrs — so the picker
+	// would otherwise hide the columns-only ones entirely. When a
+	// semconv'd key appears in both (the attribute sampler caught it in
+	// the JSONB payload), we'll merge the observation count in below so
+	// ordering still reflects real use.
+	out := matchingSyntheticFields(f.SignalType, f.Prefix)
+	byKey := make(map[string]int, len(out))
+	for i, fi := range out {
+		byKey[fi.Key] = i
+	}
+
 	// When a service is specified, constrain to that service plus the
 	// resource-level rows (service_name = '') so resource attributes still
 	// surface in autocomplete. When no service is specified, pool across
@@ -536,15 +550,81 @@ func (s *Store) ListFields(ctx context.Context, f store.FieldFilter) ([]store.Fi
 		return nil, err
 	}
 	defer rows.Close()
-	var out []store.FieldInfo
 	for rows.Next() {
 		var fi store.FieldInfo
 		if err := rows.Scan(&fi.Key, &fi.ValueType, &fi.Count); err != nil {
 			return nil, err
 		}
+		// Dedupe by key: if the synthetic list already has this key
+		// (e.g. http.route — promoted column that also appears in
+		// attribute_keys via the sampler), keep the synthetic entry's
+		// canonical type but absorb the real observation count.
+		if idx, ok := byKey[fi.Key]; ok {
+			out[idx].Count += fi.Count
+			continue
+		}
+		byKey[fi.Key] = len(out)
 		out = append(out, fi)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// syntheticFields lists the fields the query builder resolves to a
+// promoted column or a synthetic expression via realColumn() that a span
+// or log *always* has — they're intrinsic to the row, not observed
+// attributes. Keys the sampler would ever record (http.route,
+// http.request.method, rpc.service, db.system, etc.) are deliberately
+// absent: they land in attribute_keys only for services that actually
+// emit them, so service-scoped picker results stay faithful to what the
+// service actually carries.
+// Keep in sync with internal/query/builder.go:realColumn().
+var syntheticSpanFields = []store.FieldInfo{
+	{Key: "name", ValueType: "str"},
+	{Key: "service.name", ValueType: "str"},
+	{Key: "kind", ValueType: "int"},
+	{Key: "status_code", ValueType: "int"},
+	{Key: "duration_ns", ValueType: "int"},
+	{Key: "duration_ms", ValueType: "int"},
+	{Key: "start_time_ns", ValueType: "time"},
+	{Key: "parent_span_id", ValueType: "str"},
+	{Key: "trace_id", ValueType: "str"},
+	{Key: "is_root", ValueType: "bool"},
+	{Key: "error", ValueType: "bool"},
+}
+
+var syntheticLogFields = []store.FieldInfo{
+	{Key: "service.name", ValueType: "str"},
+	{Key: "severity_number", ValueType: "int"},
+	{Key: "severity_text", ValueType: "str"},
+	{Key: "body", ValueType: "str"},
+	{Key: "time_ns", ValueType: "time"},
+	{Key: "trace_id", ValueType: "str"},
+	{Key: "error", ValueType: "bool"},
+}
+
+func matchingSyntheticFields(signalType, prefix string) []store.FieldInfo {
+	var src []store.FieldInfo
+	switch signalType {
+	case "span":
+		src = syntheticSpanFields
+	case "log":
+		src = syntheticLogFields
+	default:
+		return nil
+	}
+	out := make([]store.FieldInfo, 0, len(src))
+	for _, fi := range src {
+		if prefix == "" || strings.HasPrefix(fi.Key, prefix) {
+			out = append(out, fi)
+		}
+	}
+	return out
 }
 
 func (s *Store) ListFieldValues(ctx context.Context, f store.ValueFilter) ([]string, error) {

--- a/internal/store/sqlite/queries.go
+++ b/internal/store/sqlite/queries.go
@@ -509,12 +509,29 @@ func (s *Store) ListFields(ctx context.Context, f store.FieldFilter) ([]store.Fi
 		return nil, errors.New("signal_type must be 'span' or 'log'")
 	}
 	limit := clampLimit(f.Limit, 100, 500)
-	const q = `SELECT key, value_type, SUM(count) AS c FROM attribute_keys
-		WHERE signal_type = ? AND (service_name = ? OR service_name = '')
-		  AND key LIKE ? || '%'
-		GROUP BY key, value_type
-		ORDER BY c DESC, key ASC LIMIT ?`
-	rows, err := s.reader.QueryContext(ctx, q, f.SignalType, f.Service, f.Prefix, limit)
+	// When a service is specified, constrain to that service plus the
+	// resource-level rows (service_name = '') so resource attributes still
+	// surface in autocomplete. When no service is specified, pool across
+	// every service — matches the UI's "no WHERE filter yet" state.
+	var (
+		q    string
+		args []any
+	)
+	if f.Service == "" {
+		q = `SELECT key, value_type, SUM(count) AS c FROM attribute_keys
+			WHERE signal_type = ? AND key LIKE ? || '%'
+			GROUP BY key, value_type
+			ORDER BY c DESC, key ASC LIMIT ?`
+		args = []any{f.SignalType, f.Prefix, limit}
+	} else {
+		q = `SELECT key, value_type, SUM(count) AS c FROM attribute_keys
+			WHERE signal_type = ? AND (service_name = ? OR service_name = '')
+			  AND key LIKE ? || '%'
+			GROUP BY key, value_type
+			ORDER BY c DESC, key ASC LIMIT ?`
+		args = []any{f.SignalType, f.Service, f.Prefix, limit}
+	}
+	rows, err := s.reader.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,23 +85,57 @@ func TestWriteAndReadSpan(t *testing.T) {
 		t.Fatalf("expected 1 span, got %d", len(detail.Spans))
 	}
 
+	// ListFields should surface the attribute-keys row we just wrote
+	// ("http.route" with a non-zero count) and the promoted / synthetic
+	// fields the query builder resolves natively ("name", "service.name",
+	// "duration_ns", ...). Synthetic fields carry count=0; attribute-keys
+	// rows carry the actual observation count.
 	fields, err := s.ListFields(ctx, store.FieldFilter{SignalType: "span", Service: "test"})
 	if err != nil {
 		t.Fatalf("ListFields: %v", err)
 	}
-	if len(fields) != 1 || fields[0].Key != "http.route" {
-		t.Fatalf("unexpected fields: %+v", fields)
+	keys := make(map[string]store.FieldInfo)
+	for _, fi := range fields {
+		keys[fi.Key] = fi
+	}
+	if fi, ok := keys["http.route"]; !ok || fi.Count == 0 {
+		t.Fatalf("expected http.route attribute_keys row: %+v", fields)
+	}
+	for _, k := range []string{"name", "service.name", "duration_ns", "is_root", "error"} {
+		if _, ok := keys[k]; !ok {
+			t.Fatalf("expected synthetic field %q in results: %+v", k, fields)
+		}
 	}
 
-	// With no service scope, ListFields should pool across every service
-	// so the UI's "no WHERE filter yet" state can still populate
-	// group-by / autocomplete dropdowns.
+	// Prefix-filter narrows both synthetic + attribute_keys rows.
+	prefixed, err := s.ListFields(ctx, store.FieldFilter{SignalType: "span", Prefix: "http."})
+	if err != nil {
+		t.Fatalf("ListFields prefix: %v", err)
+	}
+	for _, fi := range prefixed {
+		if !strings.HasPrefix(fi.Key, "http.") {
+			t.Fatalf("prefix leak: %+v", fi)
+		}
+	}
+	if len(prefixed) == 0 {
+		t.Fatalf("expected at least one http.* field")
+	}
+
+	// With no service scope, ListFields still returns data (regression
+	// guard for the previous bug where service_name = '' matched nothing).
 	fieldsAll, err := s.ListFields(ctx, store.FieldFilter{SignalType: "span"})
 	if err != nil {
 		t.Fatalf("ListFields (no service): %v", err)
 	}
-	if len(fieldsAll) != 1 || fieldsAll[0].Key != "http.route" {
-		t.Fatalf("unexpected cross-service fields: %+v", fieldsAll)
+	foundRoute := false
+	for _, fi := range fieldsAll {
+		if fi.Key == "http.route" {
+			foundRoute = true
+			break
+		}
+	}
+	if !foundRoute {
+		t.Fatalf("expected http.route in cross-service fields: %+v", fieldsAll)
 	}
 }
 

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -91,6 +91,17 @@ func TestWriteAndReadSpan(t *testing.T) {
 	if len(fields) != 1 || fields[0].Key != "http.route" {
 		t.Fatalf("unexpected fields: %+v", fields)
 	}
+
+	// With no service scope, ListFields should pool across every service
+	// so the UI's "no WHERE filter yet" state can still populate
+	// group-by / autocomplete dropdowns.
+	fieldsAll, err := s.ListFields(ctx, store.FieldFilter{SignalType: "span"})
+	if err != nil {
+		t.Fatalf("ListFields (no service): %v", err)
+	}
+	if len(fieldsAll) != 1 || fieldsAll[0].Key != "http.route" {
+		t.Fatalf("unexpected cross-service fields: %+v", fieldsAll)
+	}
 }
 
 func TestPercentileUDF(t *testing.T) {


### PR DESCRIPTION
## Two related bugs blocking the Group-by / WHERE-field pickers

### 1. ListFields returned nothing without a service filter

\`Store.ListFields\` ran:

```sql
WHERE signal_type = ? AND (service_name = ? OR service_name = '')
```

When the caller didn't pass a service, \`f.Service == \"\"\` so both placeholders bound to \`''\`. Real \`attribute_keys\` rows carry \`service_name = 'api-gateway'\` etc., so the predicate matched nothing — Group-by showed \"No matches\" on every open.

Split the query: \`Service == \"\"\` pools across every service; otherwise keep the \"this-service or resource-level\" union.

### 2. Promoted + synthetic fields never appeared in the picker

The attribute_keys catalog only knows **JSONB** attribute keys. The query builder's \`realColumn()\` resolves another class of keys that never live in the JSONB — \`name\`, \`service.name\`, \`kind\`, \`status_code\`, \`duration_ns\`, \`duration_ms\`, \`start_time_ns\`, \`parent_span_id\`, \`trace_id\`, \`is_root\`, \`error\` (and log-side \`severity_*\`, \`body\`, \`time_ns\`, etc.). Because \`/api/fields\` only scanned \`attribute_keys\`, none of these showed up, and users couldn't Group by any of them — even though the backend compiler was perfectly happy to run \`GROUP BY name\`.

Inject these at the top of the response. Semconv-promoted columns like \`http.route\`, \`http.request.method\`, \`db.system\` are **not** in the synthetic list: they appear in \`attribute_keys\` whenever a service emits them, so service-scoped pickers stay faithful to what that service actually carries.

When a semconv key appears in both (shouldn't happen in the set above but might in future), the synthetic entry's type is canonical and the real attribute_keys count is merged in for ordering.

## Test plan

- [x] \`go test ./...\` — including updated \`TestWriteAndReadSpan\` asserting synthetic fields and prefix filtering
- [x] Live SQL query on the running DB returns the expected data
- [x] Playwright: confirmed the 404-shaped \"No matches\" state reproducing before the fix on \`/traces\` → Group by
- [ ] After merge: restart waggle → Group by popover shows \`name\`, \`service.name\`, \`http.route\`, \`customer.tier\`, etc.; picking \`name\` + Run → grouped results

🤖 Generated with [Claude Code](https://claude.com/claude-code)