### PR TITLE
feat(ui): hover tooltips on the 6 Define cells

### DIFF
--- a/ui/src/features/query/DefineCell.tsx
+++ b/ui/src/features/query/DefineCell.tsx
@@ -1,4 +1,5 @@
 import * as RadixPopover from "@radix-ui/react-popover";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import type { ReactNode } from "react";
 
 interface Props {
@@ -6,16 +7,39 @@ interface Props {
   value: ReactNode;
   placeholder?: string;
   isEmpty?: boolean;
+  /** Short explanation of what this cell does, shown on hover of the label. */
+  description?: string;
   editor: ReactNode;
 }
 
 /**
  * One cell of Honeycomb's Define grid. Shows an uppercase label (rendered
- * as a link so the field-name is visually discoverable) with the current
- * value beneath it. Click anywhere on the cell to open the popover editor.
- * Empty state renders muted placeholder text ("None; include all events").
+ * with a dotted underline to hint at its role as a help affordance) with
+ * the current value beneath it. Clicking anywhere on the cell opens the
+ * popover editor; hovering the label surfaces a short description of what
+ * the clause does. Empty state renders muted placeholder text ("None;
+ * include all events").
  */
-export function DefineCell({ label, value, placeholder, isEmpty, editor }: Props) {
+export function DefineCell({
+  label,
+  value,
+  placeholder,
+  isEmpty,
+  description,
+  editor,
+}: Props) {
+  const labelNode = (
+    <span
+      className="text-[11px] uppercase tracking-wider font-medium"
+      style={{
+        color: "var(--color-ink-muted)",
+        textDecoration: "underline dotted",
+        textUnderlineOffset: "3px",
+      }}
+    >
+      {label}
+    </span>
+  );
   return (
     <RadixPopover.Root>
       <RadixPopover.Trigger asChild>
@@ -23,16 +47,34 @@ export function DefineCell({ label, value, placeholder, isEmpty, editor }: Props
           type="button"
           className="text-left w-full group flex flex-col gap-1 py-2 outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] rounded"
         >
-          <span
-            className="text-[11px] uppercase tracking-wider font-medium"
-            style={{
-              color: "var(--color-ink-muted)",
-              textDecoration: "underline dotted",
-              textUnderlineOffset: "3px",
-            }}
-          >
-            {label}
-          </span>
+          {description ? (
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                {/* span makes the tooltip trigger inline and keyboard-focusable
+                    independent of the outer popover button. */}
+                <span className="inline-block w-fit">{labelNode}</span>
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  side="top"
+                  align="start"
+                  sideOffset={6}
+                  className="z-50 max-w-xs rounded-md border px-2.5 py-1.5 text-xs leading-snug shadow-lg"
+                  style={{
+                    background: "var(--color-surface)",
+                    borderColor: "var(--color-border)",
+                    color: "var(--color-ink)",
+                  }}
+                  onPointerDownOutside={(e) => e.preventDefault()}
+                >
+                  {description}
+                  <Tooltip.Arrow style={{ fill: "var(--color-surface)" }} />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          ) : (
+            labelNode
+          )}
           <span
             className="text-sm"
             style={{

--- a/ui/src/features/query/DefinePanel.tsx
+++ b/ui/src/features/query/DefinePanel.tsx
@@ -94,6 +94,7 @@ export function DefinePanel({ dataset, search, onChange, onRun, isRunning }: Pro
         >
           <DefineCell
             label="Select"
+            description="What to compute. COUNT returns one number per result row; aggregations like P95, AVG, SUM, MIN/MAX, and COUNT_DISTINCT take a field and reduce its values. An empty Select returns raw events instead."
             isEmpty={false}
             value={summarizeSelect(search.select)}
             editor={
@@ -105,6 +106,7 @@ export function DefinePanel({ dataset, search, onChange, onRun, isRunning }: Pro
           />
           <DefineCell
             label="Where"
+            description="Row-level filter applied BEFORE aggregation. Events that don't match are dropped, so they won't be counted or included in percentiles. Filter on first-class fields (service.name, http.route) or any attribute key."
             isEmpty={search.where.length === 0}
             placeholder="None; include all events"
             value={summarizeFilters(search.where, "None; include all events")}
@@ -119,6 +121,7 @@ export function DefinePanel({ dataset, search, onChange, onRun, isRunning }: Pro
           />
           <DefineCell
             label="Group by"
+            description="Split results into one row per unique value of the chosen field(s) — each aggregation in Select is computed separately for each group. Example: group by service.name + aggregate P95(duration_ns) → one p95 per service."
             isEmpty={search.group_by.length === 0}
             placeholder="None; don't segment"
             value={summarizeGroupBy(search.group_by)}
@@ -137,6 +140,7 @@ export function DefinePanel({ dataset, search, onChange, onRun, isRunning }: Pro
         <div className="grid grid-cols-3 gap-6 px-5 py-1 items-end">
           <DefineCell
             label="Order by"
+            description="Sort the result rows. Reference an aggregation alias (count, p95_duration_ns, …) or a Group by field. Pair with Limit to get top-N."
             isEmpty={search.order_by.length === 0}
             placeholder="None"
             value={summarizeOrderBy(search.order_by)}
@@ -150,6 +154,7 @@ export function DefinePanel({ dataset, search, onChange, onRun, isRunning }: Pro
           />
           <DefineCell
             label="Having"
+            description="Group-level filter applied AFTER aggregation. Use it to keep only groups whose computed value matches, e.g. count > 100 or p95_duration_ns > 500000000. Where can't do this because it filters events before they're grouped."
             isEmpty={search.having.length === 0}
             placeholder="None; include all results"
             value={summarizeFilters(search.having, "None; include all results")}
@@ -166,6 +171,7 @@ export function DefinePanel({ dataset, search, onChange, onRun, isRunning }: Pro
           <div className="flex items-end justify-between gap-3">
             <DefineCell
               label="Limit"
+              description="Maximum number of result rows returned. Defaults to 1000. Combine with Order by to keep the top-N slowest / noisiest / busiest and drop the rest."
               isEmpty={search.limit === undefined}
               placeholder="1000"
               value={String(search.limit ?? "1000")}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
+import * as Tooltip from "@radix-ui/react-tooltip";
 import { router } from "./router";
 import "./styles.css";
 
@@ -18,7 +19,9 @@ const queryClient = new QueryClient({
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <Tooltip.Provider delayDuration={300} skipDelayDuration={150}>
+        <RouterProvider router={router} />
+      </Tooltip.Provider>
     </QueryClientProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

Each cell in the Define grid has a dotted-underlined label (Select, Where, Group by, Order by, Having, Limit) hinting at a help affordance — but hovering did nothing. Hook up \`@radix-ui/react-tooltip\` (already a dep) and attach a short, specific description to each.

Tooltip copy:

- **Select** — what to compute. COUNT returns one number per result row; aggregations like P95, AVG, SUM, MIN/MAX, COUNT_DISTINCT take a field and reduce its values. Empty Select returns raw events.
- **Where** — row-level filter applied BEFORE aggregation. Events that don't match are dropped, so they won't be counted or included in percentiles.
- **Group by** — split results into one row per unique value of the chosen field(s); each Select aggregation is computed separately for each group.
- **Order by** — sort result rows by an aggregation alias (count, p95_duration_ns) or a Group by field. Pair with Limit for top-N.
- **Having** — group-level filter applied AFTER aggregation. Use for \`count > 100\` style predicates that WHERE can't express.
- **Limit** — max result rows returned. Defaults to 1000. Combine with Order by for top-N.

## Implementation

- Added \`Tooltip.Provider\` at the app root (\`main.tsx\`) with \`delayDuration=300\` so tooltips don't flash on quick mouse passes.
- \`DefineCell\` gains a \`description?: string\` prop; the label span becomes the tooltip trigger while the outer cell button remains the popover trigger — hover the label for help, click anywhere for the editor.
- \`onPointerDownOutside preventDefault\` on the tooltip content stops it from intercepting the click that opens the popover.

## Test plan

- [x] \`npx tsc --noEmit -p tsconfig.app.json\`
- [ ] Visual: rebuild waggle, hover each label → tooltip shows; click the cell → popover opens; keyboard-tab to a cell → focus ring visible, tooltip also appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)