### PR TITLE
test(e2e): broad OTel SDK integration suite

### DIFF
--- a/internal/ingest/e2e_fixture_test.go
+++ b/internal/ingest/e2e_fixture_test.go
@@ -1,0 +1,302 @@
+package ingest_test
+
+// e2eFixture wires the full server-shape used by `cmd/waggle/main.go`:
+// ingest.Handler on /v1/{traces,logs} + api.Router on /api/* against a
+// single SQLite store, fronted by a single httptest.Server. Tests can
+// then (a) emit via the real OTel Go SDK and (b) call the UI-facing
+// /api/* endpoints, asserting round-trip correctness end-to-end.
+//
+// The existing sdk_integration_test.go `fixture` only mounts the ingest
+// path — the tests below that need to query data go direct to the store.
+// This richer fixture is what the new SDK-driven API integration tests
+// consume, separate from the simpler fixture so we don't churn the older
+// assertions.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/danielloader/waggle/internal/api"
+	"github.com/danielloader/waggle/internal/ingest"
+	"github.com/danielloader/waggle/internal/store/sqlite"
+)
+
+type e2eFixture struct {
+	t      *testing.T
+	ctx    context.Context
+	cancel context.CancelFunc
+	st     *sqlite.Store
+	writer *ingest.Writer
+	srv    *httptest.Server
+}
+
+func newE2EFixture(t *testing.T) *e2eFixture {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	st, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	w := ingest.NewWriter(st, log, ingest.WriterConfig{
+		FlushEvery: 5 * time.Millisecond,
+		FlushSpans: 10,
+		FlushLogs:  10,
+	})
+	w.Start(ctx)
+
+	ih := ingest.NewHandler(w, log)
+	apiRouter := api.NewRouter(st, log)
+
+	mux := http.NewServeMux()
+	ih.Mount(mux)
+	apiRouter.Mount(mux)
+
+	srv := httptest.NewServer(mux)
+	return &e2eFixture{t: t, ctx: ctx, cancel: cancel, st: st, writer: w, srv: srv}
+}
+
+func (f *e2eFixture) close() {
+	f.srv.Close()
+	sctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = f.writer.Stop(sctx)
+	_ = f.st.Close()
+	f.cancel()
+}
+
+// endpointHost returns "127.0.0.1:PORT" — the host:port form the OTLP/HTTP
+// exporter wants via WithEndpoint().
+func (f *e2eFixture) endpointHost() string {
+	u, err := url.Parse(f.srv.URL)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	return u.Host
+}
+
+// apiURL builds the absolute URL for an /api path. Tests read from here
+// via net/http so we're exercising the real handler chain, not the
+// router directly.
+func (f *e2eFixture) apiURL(path string) string {
+	return f.srv.URL + path
+}
+
+// tracerProvider builds a fresh OTel TracerProvider pointing at this
+// fixture's ingest endpoint, tagged with the given service.name. Short
+// batch timeout keeps test runtime low.
+func (f *e2eFixture) tracerProvider(service string) *sdktrace.TracerProvider {
+	f.t.Helper()
+	exp, err := otlptracehttp.New(f.ctx,
+		otlptracehttp.WithEndpoint(f.endpointHost()),
+		otlptracehttp.WithInsecure(),
+	)
+	if err != nil {
+		f.t.Fatalf("otlptracehttp.New: %v", err)
+	}
+	res, err := resource.New(f.ctx, resource.WithAttributes(
+		attribute.String("service.name", service),
+		attribute.String("service.version", "e2e-test"),
+		attribute.String("deployment.environment", "test"),
+	))
+	if err != nil {
+		f.t.Fatalf("resource.New: %v", err)
+	}
+	return sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp,
+			sdktrace.WithBatchTimeout(50*time.Millisecond),
+			sdktrace.WithMaxExportBatchSize(256),
+		),
+		sdktrace.WithResource(res),
+	)
+}
+
+// loggerProvider is the log-side counterpart to tracerProvider.
+func (f *e2eFixture) loggerProvider(service string) *sdklog.LoggerProvider {
+	f.t.Helper()
+	exp, err := otlploghttp.New(f.ctx,
+		otlploghttp.WithEndpoint(f.endpointHost()),
+		otlploghttp.WithInsecure(),
+	)
+	if err != nil {
+		f.t.Fatalf("otlploghttp.New: %v", err)
+	}
+	res, err := resource.New(f.ctx, resource.WithAttributes(
+		attribute.String("service.name", service),
+		attribute.String("service.version", "e2e-test"),
+		attribute.String("deployment.environment", "test"),
+	))
+	if err != nil {
+		f.t.Fatalf("resource.New: %v", err)
+	}
+	return sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewBatchProcessor(exp,
+			sdklog.WithExportInterval(50*time.Millisecond),
+			sdklog.WithExportMaxBatchSize(256),
+		)),
+		sdklog.WithResource(res),
+	)
+}
+
+// shutdownTracer flushes then shuts down a tracer provider. Use after
+// span emission so spans hit the ingest endpoint before assertions run.
+func (f *e2eFixture) shutdownTracer(tp *sdktrace.TracerProvider) {
+	f.t.Helper()
+	sctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := tp.Shutdown(sctx); err != nil {
+		f.t.Fatalf("tracer shutdown: %v", err)
+	}
+}
+
+// shutdownLogger flushes + shuts down a logger provider.
+func (f *e2eFixture) shutdownLogger(lp *sdklog.LoggerProvider) {
+	f.t.Helper()
+	sctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := lp.Shutdown(sctx); err != nil {
+		f.t.Fatalf("logger shutdown: %v", err)
+	}
+}
+
+// waitForSpanCount polls the store until service `svc` has at least n
+// spans or the deadline expires.
+func (f *e2eFixture) waitForSpanCount(svc string, n int) {
+	f.t.Helper()
+	waitFor(f.t, 3*time.Second, fmt.Sprintf("spans for %q >= %d", svc, n), func() bool {
+		services, err := f.st.ListServices(f.ctx)
+		if err != nil {
+			return false
+		}
+		for _, s := range services {
+			if s.ServiceName == svc && s.SpanCount >= int64(n) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// waitForTotalSpanCount polls until the sum of span counts across all
+// services reaches at least n.
+func (f *e2eFixture) waitForTotalSpanCount(n int) {
+	f.t.Helper()
+	waitFor(f.t, 3*time.Second, fmt.Sprintf("total spans >= %d", n), func() bool {
+		services, err := f.st.ListServices(f.ctx)
+		if err != nil {
+			return false
+		}
+		var total int64
+		for _, s := range services {
+			total += s.SpanCount
+		}
+		return total >= int64(n)
+	})
+}
+
+// waitForLogCount polls the /api/logs/search endpoint until it returns
+// at least n records. Use this instead of poking the store directly so
+// we also validate the HTTP-side behaviour.
+func (f *e2eFixture) waitForLogCount(n int) {
+	f.t.Helper()
+	waitFor(f.t, 3*time.Second, fmt.Sprintf("logs >= %d", n), func() bool {
+		var resp struct {
+			Logs []map[string]any `json:"logs"`
+		}
+		if err := f.getJSON("/api/logs/search?limit=1000", &resp); err != nil {
+			return false
+		}
+		return len(resp.Logs) >= n
+	})
+}
+
+// getJSON performs a GET against /api and decodes into out. Fails the
+// test on transport error or non-200 status.
+func (f *e2eFixture) getJSON(path string, out any) error {
+	f.t.Helper()
+	resp, err := http.Get(f.apiURL(path))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("GET %s: %d %s", path, resp.StatusCode, string(b))
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// postJSON posts the given body to /api and decodes the response. Any
+// non-2xx status is returned as an error with the response body.
+func (f *e2eFixture) postJSON(path string, body any, out any) error {
+	f.t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	resp, err := http.Post(f.apiURL(path), "application/json", bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("POST %s: %d %s", path, resp.StatusCode, string(raw))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.Unmarshal(raw, out)
+}
+
+// runQueryAPI is a thin typed wrapper around POST /api/query for tests
+// that want to assert on structured results without re-declaring the
+// result shape every time.
+type apiQueryResult struct {
+	Columns []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"columns"`
+	Rows [][]any `json:"rows"`
+}
+
+func (f *e2eFixture) runQueryAPI(body map[string]any) (*apiQueryResult, error) {
+	var out apiQueryResult
+	if err := f.postJSON("/api/query", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// columnIdx returns the column index for a given name or -1.
+func (r *apiQueryResult) columnIdx(name string) int {
+	for i, c := range r.Columns {
+		if c.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// rfc3339 formats a time for inclusion in an API query time_range.
+func rfc3339(t time.Time) string { return t.UTC().Format(time.RFC3339Nano) }

--- a/internal/ingest/e2e_logs_test.go
+++ b/internal/ingest/e2e_logs_test.go
@@ -1,0 +1,396 @@
+package ingest_test
+
+// SDK-driven log edge cases. Coverage:
+//
+// - Full OTel severity spectrum (TRACE..FATAL) round-trips as numeric
+//   severity_number, and the synthetic `error` field fires at >= ERROR.
+// - Logs emitted inside an active span pick up trace_id/span_id
+//   automatically from context and expose them on /api/logs/search.
+// - Logs emitted with no span context land with empty trace/span bytes.
+// - Structured map bodies round-trip as JSON on the body column.
+// - FTS search via WHERE body contains X narrows results correctly.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	otellog "go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ---------------------------------------------------------------------------
+// Severity spectrum.
+// ---------------------------------------------------------------------------
+
+func TestE2E_LogSeverityLevels(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	lp := f.loggerProvider("sev-svc")
+	logger := lp.Logger("e2e")
+
+	emissions := []struct {
+		sev  otellog.Severity
+		text string
+		body string
+	}{
+		{otellog.SeverityTrace1, "TRACE", "trace level"},
+		{otellog.SeverityDebug, "DEBUG", "cache miss"},
+		{otellog.SeverityInfo, "INFO", "request served"},
+		{otellog.SeverityWarn, "WARN", "retry attempt"},
+		{otellog.SeverityError, "ERROR", "upstream 500"},
+		{otellog.SeverityFatal, "FATAL", "panic shutdown"},
+	}
+	for _, e := range emissions {
+		var r otellog.Record
+		r.SetTimestamp(time.Now())
+		r.SetObservedTimestamp(time.Now())
+		r.SetSeverity(e.sev)
+		r.SetSeverityText(e.text)
+		r.SetBody(otellog.StringValue(e.body))
+		logger.Emit(context.Background(), r)
+	}
+	f.shutdownLogger(lp)
+	f.waitForLogCount(len(emissions))
+
+	// Total count first.
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "logs",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{{"op": "count"}},
+		"where":  []map[string]any{{"field": "service.name", "op": "=", "value": "sev-svc"}},
+	})
+	if err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	count, _ := toInt64(res.Rows[0][res.columnIdx("count")])
+	if count != int64(len(emissions)) {
+		t.Fatalf("want %d logs, got %d", len(emissions), count)
+	}
+
+	// Synthetic `error` should match ERROR + FATAL only (severity_number >= 17).
+	res, err = f.runQueryAPI(map[string]any{
+		"dataset": "logs",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{{"op": "count"}},
+		"where": []map[string]any{
+			{"field": "service.name", "op": "=", "value": "sev-svc"},
+			{"field": "error", "op": "=", "value": true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("error query: %v", err)
+	}
+	errCount, _ := toInt64(res.Rows[0][res.columnIdx("count")])
+	if errCount != 2 {
+		t.Errorf("want 2 error-or-higher logs, got %d", errCount)
+	}
+
+	// Group by severity_number — each level has count 1.
+	res, err = f.runQueryAPI(map[string]any{
+		"dataset": "logs",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select":   []map[string]any{{"op": "count"}},
+		"where":    []map[string]any{{"field": "service.name", "op": "=", "value": "sev-svc"}},
+		"group_by": []string{"severity_number"},
+	})
+	if err != nil {
+		t.Fatalf("severity group-by query: %v", err)
+	}
+	distribution := map[int64]int64{}
+	for _, row := range res.Rows {
+		sev, _ := toInt64(row[res.columnIdx("severity_number")])
+		c, _ := toInt64(row[res.columnIdx("count")])
+		distribution[sev] = c
+	}
+	// TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17, FATAL=21 per the OTel spec.
+	for _, sev := range []int64{1, 5, 9, 13, 17, 21} {
+		if distribution[sev] != 1 {
+			t.Errorf("severity %d: want count 1, got %d (full map %v)",
+				sev, distribution[sev], distribution)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Trace-log correlation: a log emitted inside an active span's context
+// inherits trace_id + span_id automatically via the OTel SDK.
+// ---------------------------------------------------------------------------
+
+func TestE2E_LogTraceCorrelation(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("corr-svc")
+	lp := f.loggerProvider("corr-svc")
+	tr := tp.Tracer("e2e")
+	logger := lp.Logger("e2e")
+
+	// Correlated: log emitted with the span's ctx.
+	ctx, span := tr.Start(context.Background(), "work.do")
+	var r otellog.Record
+	r.SetTimestamp(time.Now())
+	r.SetObservedTimestamp(time.Now())
+	r.SetSeverity(otellog.SeverityInfo)
+	r.SetSeverityText("INFO")
+	r.SetBody(otellog.StringValue("inside span"))
+	logger.Emit(ctx, r)
+	wantTraceID := span.SpanContext().TraceID().String()
+	wantSpanID := span.SpanContext().SpanID().String()
+	span.End()
+
+	// Uncorrelated: log emitted with a bare Background ctx — no active span.
+	var r2 otellog.Record
+	r2.SetTimestamp(time.Now())
+	r2.SetObservedTimestamp(time.Now())
+	r2.SetSeverity(otellog.SeverityInfo)
+	r2.SetSeverityText("INFO")
+	r2.SetBody(otellog.StringValue("outside span"))
+	logger.Emit(context.Background(), r2)
+
+	f.shutdownTracer(tp)
+	f.shutdownLogger(lp)
+	f.waitForLogCount(2)
+
+	var resp struct {
+		Logs []struct {
+			Body    string `json:"body"`
+			TraceID string `json:"trace_id"`
+			SpanID  string `json:"span_id"`
+		} `json:"logs"`
+	}
+	if err := f.getJSON("/api/logs/search?service=corr-svc&limit=10", &resp); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	var inside, outside *struct {
+		Body    string `json:"body"`
+		TraceID string `json:"trace_id"`
+		SpanID  string `json:"span_id"`
+	}
+	for i := range resp.Logs {
+		switch resp.Logs[i].Body {
+		case "inside span":
+			inside = &resp.Logs[i]
+		case "outside span":
+			outside = &resp.Logs[i]
+		}
+	}
+	if inside == nil || outside == nil {
+		t.Fatalf("missing expected log rows: %+v", resp.Logs)
+	}
+	if !strings.EqualFold(inside.TraceID, wantTraceID) {
+		t.Errorf("inside.trace_id: want %s, got %s", wantTraceID, inside.TraceID)
+	}
+	if !strings.EqualFold(inside.SpanID, wantSpanID) {
+		t.Errorf("inside.span_id: want %s, got %s", wantSpanID, inside.SpanID)
+	}
+	if outside.TraceID != "" {
+		t.Errorf("outside log should have no trace_id, got %q", outside.TraceID)
+	}
+	if outside.SpanID != "" {
+		t.Errorf("outside log should have no span_id, got %q", outside.SpanID)
+	}
+	// Sanity: the correlated span's trace_id matches a trace in /api/traces.
+	if _, err := trace.TraceIDFromHex(wantTraceID); err != nil {
+		t.Fatalf("wantTraceID not valid hex: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Structured bodies: a map body should land as JSON on the body column.
+// ---------------------------------------------------------------------------
+
+func TestE2E_LogStructuredBody(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	lp := f.loggerProvider("body-svc")
+	logger := lp.Logger("e2e")
+
+	// Map body with nested scalars.
+	var r otellog.Record
+	r.SetTimestamp(time.Now())
+	r.SetSeverity(otellog.SeverityInfo)
+	r.SetSeverityText("INFO")
+	r.SetBody(otellog.MapValue(
+		otellog.String("user", "alice"),
+		otellog.Int("orders", 7),
+		otellog.Bool("staff", false),
+	))
+	logger.Emit(context.Background(), r)
+
+	f.shutdownLogger(lp)
+	f.waitForLogCount(1)
+
+	var resp struct {
+		Logs []struct {
+			Body string `json:"body"`
+		} `json:"logs"`
+	}
+	if err := f.getJSON("/api/logs/search?service=body-svc&limit=5", &resp); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(resp.Logs) != 1 {
+		t.Fatalf("want 1 log, got %d", len(resp.Logs))
+	}
+	// Body should be either a JSON-serialised map or at minimum contain
+	// the keys — waggle may render map bodies as JSON on the body column
+	// or stash the structured form on body_json. Accept either, but we
+	// must find the keys SOMEWHERE on the record. Fetch again with the
+	// full row via /api/query raw-events mode.
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "logs",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{},
+		"where":  []map[string]any{{"field": "service.name", "op": "=", "value": "body-svc"}},
+		"limit":  5,
+	})
+	if err != nil {
+		t.Fatalf("raw logs query: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("raw logs: want 1 row, got %d", len(res.Rows))
+	}
+	// Body round-trips as a JSON-encoded string on the `body` column
+	// (the backend stringifies structured bodies). Decode it and assert
+	// on the resulting map so the test doesn't fight escape quoting.
+	bodyIdx := res.columnIdx("body")
+	if bodyIdx < 0 {
+		t.Fatalf("no body column in raw result: %+v", res.Columns)
+	}
+	bodyStr, ok := res.Rows[0][bodyIdx].(string)
+	if !ok {
+		t.Fatalf("body column is %T, expected string", res.Rows[0][bodyIdx])
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(bodyStr), &decoded); err != nil {
+		t.Fatalf("body wasn't valid JSON: %v (raw %q)", err, bodyStr)
+	}
+	if decoded["user"] != "alice" {
+		t.Errorf("body.user: want alice, got %v", decoded["user"])
+	}
+	if got, _ := toInt64(decoded["orders"]); got != 7 {
+		t.Errorf("body.orders: want 7, got %v", decoded["orders"])
+	}
+	if decoded["staff"] != false {
+		t.Errorf("body.staff: want false, got %v", decoded["staff"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Attribute filtering on logs: a WHERE filter on a log attribute key
+// must narrow results correctly.
+// ---------------------------------------------------------------------------
+
+func TestE2E_LogAttributeFiltering(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	lp := f.loggerProvider("attrs-log-svc")
+	logger := lp.Logger("e2e")
+
+	// 10 logs: 4 with http.method=GET, 6 with http.method=POST.
+	for i := range 10 {
+		var r otellog.Record
+		r.SetTimestamp(time.Now())
+		r.SetSeverity(otellog.SeverityInfo)
+		r.SetSeverityText("INFO")
+		r.SetBody(otellog.StringValue(fmt.Sprintf("req-%d", i)))
+		method := "POST"
+		if i%5 < 2 {
+			method = "GET"
+		}
+		r.AddAttributes(otellog.String("http.method", method))
+		logger.Emit(context.Background(), r)
+	}
+	f.shutdownLogger(lp)
+	f.waitForLogCount(10)
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "logs",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{{"op": "count"}},
+		"where": []map[string]any{
+			{"field": "service.name", "op": "=", "value": "attrs-log-svc"},
+			{"field": "http.method", "op": "=", "value": "GET"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("count GET: %v", err)
+	}
+	gotGet, _ := toInt64(res.Rows[0][res.columnIdx("count")])
+	if gotGet != 4 {
+		t.Errorf("GET count: want 4, got %d", gotGet)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FTS-style body contains: WHERE body contains X narrows to matching logs.
+// ---------------------------------------------------------------------------
+
+func TestE2E_LogBodyContains(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	lp := f.loggerProvider("fts-svc")
+	logger := lp.Logger("e2e")
+
+	bodies := []string{
+		"request refused: rate limit exceeded",
+		"request served OK",
+		"upstream timeout after 5s",
+		"connection refused to partner-webhook",
+		"all systems normal",
+	}
+	for _, b := range bodies {
+		var r otellog.Record
+		r.SetTimestamp(time.Now())
+		r.SetSeverity(otellog.SeverityInfo)
+		r.SetSeverityText("INFO")
+		r.SetBody(otellog.StringValue(b))
+		logger.Emit(context.Background(), r)
+	}
+	f.shutdownLogger(lp)
+	f.waitForLogCount(len(bodies))
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "logs",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{{"op": "count"}},
+		"where": []map[string]any{
+			{"field": "service.name", "op": "=", "value": "fts-svc"},
+			{"field": "body", "op": "contains", "value": "refused"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("contains query: %v", err)
+	}
+	count, _ := toInt64(res.Rows[0][res.columnIdx("count")])
+	if count != 2 {
+		t.Errorf("body contains 'refused': want 2, got %d", count)
+	}
+}

--- a/internal/ingest/e2e_ops_test.go
+++ b/internal/ingest/e2e_ops_test.go
@@ -1,0 +1,412 @@
+package ingest_test
+
+// E2E coverage for the management + catalogue surface:
+//
+// - POST /api/clear wipes every signal table.
+// - store.Retain() enforces the time-based retention cutoff.
+// - /api/fields surfaces both JSONB-observed keys and the promoted /
+//   synthetic fields the query builder resolves natively, with and
+//   without a service scope.
+// - /api/fields/{key}/values returns actual observed values.
+// - /api/span-names returns the span names for a service.
+// - /api/traces has_error filter.
+// - POST /api/query returns 400 on malformed payloads (cheap negative
+//   path so parsing regressions can't silently slip through).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ---------------------------------------------------------------------------
+// Clear nukes everything.
+// ---------------------------------------------------------------------------
+
+func TestE2E_ClearEndpoint(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("clear-svc")
+	tr := tp.Tracer("e2e")
+	_, span := tr.Start(context.Background(), "op")
+	span.End()
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("clear-svc", 1)
+
+	if err := f.postJSON("/api/clear", map[string]any{}, nil); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+
+	// /api/services should now be empty.
+	var svcResp struct {
+		Services []any `json:"services"`
+	}
+	if err := f.getJSON("/api/services", &svcResp); err != nil {
+		t.Fatalf("services: %v", err)
+	}
+	if len(svcResp.Services) != 0 {
+		t.Errorf("services after clear: want empty, got %d", len(svcResp.Services))
+	}
+
+	// A query for the same window should also return zero count.
+	now := time.Now()
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(now.Add(-5 * time.Minute)),
+			"to":   rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{{"op": "count"}},
+	})
+	if err != nil {
+		t.Fatalf("post-clear query: %v", err)
+	}
+	c, _ := toInt64(res.Rows[0][res.columnIdx("count")])
+	if c != 0 {
+		t.Errorf("count after clear: want 0, got %d", c)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Retention cutoff drops old data but keeps anything newer.
+// ---------------------------------------------------------------------------
+
+func TestE2E_Retention(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("retain-svc")
+	tr := tp.Tracer("e2e")
+
+	// Two spans. We emit, shut down the SDK, then capture a "now" cutoff
+	// and sleep before emitting a second batch so the two groups straddle
+	// it in wall-clock time.
+	for i := 0; i < 2; i++ {
+		_, span := tr.Start(context.Background(), "old")
+		span.End()
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("retain-svc", 2)
+
+	// Nanosecond cutoff captured AFTER the old spans flushed.
+	cutoff := time.Now().UnixNano()
+	time.Sleep(3 * time.Millisecond)
+
+	tp2 := f.tracerProvider("retain-svc")
+	tr2 := tp2.Tracer("e2e")
+	for i := 0; i < 3; i++ {
+		_, span := tr2.Start(context.Background(), "new")
+		span.End()
+	}
+	f.shutdownTracer(tp2)
+	f.waitForSpanCount("retain-svc", 5)
+
+	// Directly invoke retain with our cutoff; old spans should vanish.
+	if err := f.st.Retain(f.ctx, cutoff); err != nil {
+		t.Fatalf("retain: %v", err)
+	}
+
+	var svcResp struct {
+		Services []struct {
+			Service   string `json:"service"`
+			SpanCount int64  `json:"span_count"`
+		} `json:"services"`
+	}
+	if err := f.getJSON("/api/services", &svcResp); err != nil {
+		t.Fatalf("services: %v", err)
+	}
+	var svcCount int64
+	for _, s := range svcResp.Services {
+		if s.Service == "retain-svc" {
+			svcCount = s.SpanCount
+		}
+	}
+	if svcCount != 3 {
+		t.Errorf("retain-svc span_count after cutoff: want 3 (new), got %d", svcCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// /api/fields returns both JSONB keys and synthetic fields, and scopes
+// correctly by service.
+// ---------------------------------------------------------------------------
+
+func TestE2E_FieldCatalog(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	apiTP := f.tracerProvider("gw-fc")
+	dbTP := f.tracerProvider("db-fc")
+	api := apiTP.Tracer("e2e")
+	db := dbTP.Tracer("e2e")
+
+	// gw-fc spans get http.route; db-fc spans get db.system. No overlap
+	// in attribute keys so we can assert scoping holds.
+	_, s1 := api.Start(context.Background(), "GET /x")
+	s1.SetAttributes(attribute.String("http.route", "/x"))
+	s1.End()
+	_, s2 := db.Start(context.Background(), "SELECT")
+	s2.SetAttributes(attribute.String("db.system", "postgresql"))
+	s2.End()
+	f.shutdownTracer(apiTP)
+	f.shutdownTracer(dbTP)
+	f.waitForTotalSpanCount(2)
+
+	type fieldInfo struct {
+		Key       string `json:"key"`
+		ValueType string `json:"type"`
+	}
+	// Cross-service call: synthetic fields present; both attribute keys visible.
+	var all struct {
+		Fields []fieldInfo `json:"fields"`
+	}
+	if err := f.getJSON("/api/fields?dataset=span&limit=100", &all); err != nil {
+		t.Fatalf("fields (all): %v", err)
+	}
+	got := map[string]string{}
+	for _, fi := range all.Fields {
+		got[fi.Key] = fi.ValueType
+	}
+	// Synthetic — always present.
+	for _, k := range []string{"name", "service.name", "duration_ns", "duration_ms", "is_root", "error"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("synthetic field %q missing (cross-service)", k)
+		}
+	}
+	// JSONB attribute keys — both services' keys should appear.
+	for _, k := range []string{"http.route", "db.system"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("attribute key %q missing (cross-service)", k)
+		}
+	}
+
+	// Service-scoped: db-fc should have db.system but NOT http.route.
+	var dbOnly struct {
+		Fields []fieldInfo `json:"fields"`
+	}
+	if err := f.getJSON("/api/fields?dataset=span&service=db-fc&limit=100", &dbOnly); err != nil {
+		t.Fatalf("fields (db-fc): %v", err)
+	}
+	seen := map[string]bool{}
+	for _, fi := range dbOnly.Fields {
+		seen[fi.Key] = true
+	}
+	if !seen["db.system"] {
+		t.Errorf("db.system missing on db-fc scope: %+v", dbOnly.Fields)
+	}
+	if seen["http.route"] {
+		t.Errorf("http.route leaked into db-fc scope: %+v", dbOnly.Fields)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// /api/fields/{key}/values: returns observed values, ordered by frequency.
+// ---------------------------------------------------------------------------
+
+func TestE2E_FieldValues(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("values-svc")
+	tr := tp.Tracer("e2e")
+
+	tiers := []string{"free", "silver", "gold", "gold", "gold", "free"}
+	for _, tier := range tiers {
+		_, span := tr.Start(context.Background(), "op")
+		span.SetAttributes(attribute.String("customer.tier", tier))
+		span.End()
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("values-svc", len(tiers))
+
+	var resp struct {
+		Values []string `json:"values"`
+	}
+	if err := f.getJSON("/api/fields/customer.tier/values?dataset=span&limit=10", &resp); err != nil {
+		t.Fatalf("values: %v", err)
+	}
+	want := map[string]bool{"free": false, "silver": false, "gold": false}
+	for _, v := range resp.Values {
+		if _, ok := want[v]; ok {
+			want[v] = true
+		}
+	}
+	for k, saw := range want {
+		if !saw {
+			t.Errorf("value %q missing from /api/fields/customer.tier/values: %+v", k, resp.Values)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// /api/span-names returns distinct span names for a service.
+// ---------------------------------------------------------------------------
+
+func TestE2E_SpanNames(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("names-svc")
+	tr := tp.Tracer("e2e")
+
+	for _, n := range []string{"auth", "auth", "checkout", "refund"} {
+		_, span := tr.Start(context.Background(), n)
+		span.End()
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("names-svc", 4)
+
+	var resp struct {
+		Names []string `json:"names"`
+	}
+	if err := f.getJSON("/api/span-names?service=names-svc&limit=10", &resp); err != nil {
+		t.Fatalf("span-names: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, n := range resp.Names {
+		seen[n] = true
+	}
+	for _, n := range []string{"auth", "checkout", "refund"} {
+		if !seen[n] {
+			t.Errorf("span name %q missing: %+v", n, resp.Names)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// has_error filter on ListTraces.
+// ---------------------------------------------------------------------------
+
+func TestE2E_HasErrorFilter(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("err-svc")
+	tr := tp.Tracer("e2e")
+
+	// 2 clean traces.
+	for i := 0; i < 2; i++ {
+		_, s := tr.Start(context.Background(), "ok.op", trace.WithNewRoot())
+		s.End()
+		time.Sleep(200 * time.Microsecond)
+	}
+	// 3 errored traces (status=Error).
+	for i := 0; i < 3; i++ {
+		_, s := tr.Start(context.Background(), "bad.op", trace.WithNewRoot())
+		s.SetStatus(codes.Error, "bad")
+		s.End()
+		time.Sleep(200 * time.Microsecond)
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("err-svc", 5)
+
+	var allTraces struct {
+		Traces []struct {
+			HasError bool `json:"has_error"`
+		} `json:"traces"`
+	}
+	if err := f.getJSON("/api/traces?service=err-svc&limit=20", &allTraces); err != nil {
+		t.Fatalf("all: %v", err)
+	}
+	if len(allTraces.Traces) != 5 {
+		t.Errorf("total traces: want 5, got %d", len(allTraces.Traces))
+	}
+
+	var errored struct {
+		Traces []struct {
+			HasError bool `json:"has_error"`
+		} `json:"traces"`
+	}
+	if err := f.getJSON("/api/traces?service=err-svc&limit=20&has_error=true", &errored); err != nil {
+		t.Fatalf("errored: %v", err)
+	}
+	if len(errored.Traces) != 3 {
+		t.Errorf("has_error=true: want 3 traces, got %d", len(errored.Traces))
+	}
+	for _, tr := range errored.Traces {
+		if !tr.HasError {
+			t.Errorf("returned trace with has_error=false under has_error=true filter: %+v", tr)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: /api/query with an invalid operator returns 400 + a helpful
+// message. Catches parser regressions without needing a dataset.
+// ---------------------------------------------------------------------------
+
+func TestE2E_InvalidQuery(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	now := time.Now()
+	body := map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(now.Add(-1 * time.Minute)),
+			"to":   rfc3339(now),
+		},
+		"select": []map[string]any{{"op": "bogus", "field": "whatever"}},
+	}
+	resp, err := http.Post(f.apiURL("/api/query"),
+		"application/json", bytes.NewReader(mustJSON(t, body)))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: malformed OTLP body → decode error.
+// ---------------------------------------------------------------------------
+
+func TestE2E_MalformedOTLP(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	// Garbage protobuf bytes against the trace ingest.
+	resp, err := http.Post(f.srv.URL+"/v1/traces",
+		"application/x-protobuf", bytes.NewReader([]byte{0xde, 0xad, 0xbe, 0xef}))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("garbage OTLP: want 400, got %d", resp.StatusCode)
+	}
+
+	// Unsupported content type should hit the 415 path.
+	resp2, err := http.Post(f.srv.URL+"/v1/traces",
+		"text/plain", bytes.NewReader([]byte("hi")))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnsupportedMediaType {
+		t.Fatalf("bad content type: want 415, got %d", resp2.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/internal/ingest/e2e_query_test.go
+++ b/internal/ingest/e2e_query_test.go
@@ -1,0 +1,464 @@
+package ingest_test
+
+// End-to-end coverage of the /api/query surface. Every test here drives
+// real data through the SDK -> ingest -> sqlite pipeline, then issues
+// POST /api/query with varied aggregations + group-bys + windowing and
+// asserts the response shape.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ---------------------------------------------------------------------------
+// Aggregations over duration: AVG/MIN/MAX/SUM all compute against
+// duration_ns, with values sanity-checked against what we emitted.
+// ---------------------------------------------------------------------------
+
+func TestE2E_DurationAggregations(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("agg-svc")
+	tr := tp.Tracer("e2e")
+
+	// Emit spans with durations 10ms, 20ms, …, 100ms (10 spans).
+	// We sleep the real wall-clock so start/end_time_ns reflect the gap.
+	for i := 1; i <= 10; i++ {
+		_, span := tr.Start(context.Background(), fmt.Sprintf("op-%d", i))
+		time.Sleep(time.Duration(i) * time.Millisecond)
+		span.End()
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("agg-svc", 10)
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{
+			{"op": "avg", "field": "duration_ms"},
+			{"op": "min", "field": "duration_ms"},
+			{"op": "max", "field": "duration_ms"},
+			{"op": "sum", "field": "duration_ms"},
+			{"op": "count"},
+		},
+		"where": []map[string]any{{"field": "service.name", "op": "=", "value": "agg-svc"}},
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	row := res.Rows[0]
+	// Sleep jitter is substantial on CI, but the relationships between
+	// aggregates should always hold regardless of scheduler noise:
+	//   min <= avg <= max, sum >= max * 1, count = 10.
+	avg, _ := toFloat(row[res.columnIdx("avg_duration_ms")])
+	minv, _ := toFloat(row[res.columnIdx("min_duration_ms")])
+	maxv, _ := toFloat(row[res.columnIdx("max_duration_ms")])
+	sum, _ := toFloat(row[res.columnIdx("sum_duration_ms")])
+	count, _ := toInt64(row[res.columnIdx("count")])
+	if count != 10 {
+		t.Errorf("count: want 10, got %d", count)
+	}
+	if minv > avg || avg > maxv {
+		t.Errorf("expected min <= avg <= max, got min=%v avg=%v max=%v", minv, avg, maxv)
+	}
+	if sum < maxv {
+		t.Errorf("sum (%v) < max (%v)?", sum, maxv)
+	}
+	if minv < 0 || maxv > 500 {
+		t.Errorf("duration_ms out of sane range: min=%v max=%v", minv, maxv)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Percentiles run against a wide duration spread.
+// ---------------------------------------------------------------------------
+
+func TestE2E_Percentiles(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("p-svc")
+	tr := tp.Tracer("e2e")
+
+	// 20 fast spans around ~1ms, 5 slow ones around ~50ms. p50 should be
+	// fast, p95 should jump into the slow tier.
+	for i := 0; i < 20; i++ {
+		_, span := tr.Start(context.Background(), "fast")
+		time.Sleep(1 * time.Millisecond)
+		span.End()
+	}
+	for i := 0; i < 5; i++ {
+		_, span := tr.Start(context.Background(), "slow")
+		time.Sleep(50 * time.Millisecond)
+		span.End()
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("p-svc", 25)
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{
+			{"op": "p50", "field": "duration_ms"},
+			{"op": "p95", "field": "duration_ms"},
+			{"op": "p99", "field": "duration_ms"},
+		},
+		"where": []map[string]any{{"field": "service.name", "op": "=", "value": "p-svc"}},
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	p50, _ := toFloat(res.Rows[0][res.columnIdx("p50_duration_ms")])
+	p95, _ := toFloat(res.Rows[0][res.columnIdx("p95_duration_ms")])
+	p99, _ := toFloat(res.Rows[0][res.columnIdx("p99_duration_ms")])
+	if p50 >= p95 || p95 > p99+0.01 {
+		t.Errorf("expected p50 < p95 <= p99, got p50=%v p95=%v p99=%v", p50, p95, p99)
+	}
+	if p50 > 10 {
+		t.Errorf("p50 should be in the fast tier (~1ms), got %v", p50)
+	}
+	if p95 < 10 {
+		t.Errorf("p95 should fall into the slow tier (~50ms), got %v", p95)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// count_distinct is backed by a SQL COUNT(DISTINCT …) over the JSON
+// attribute key. Emit spans with 3 distinct values for `customer.tier`;
+// verify the aggregate returns 3.
+// ---------------------------------------------------------------------------
+
+func TestE2E_CountDistinct(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("cd-svc")
+	tr := tp.Tracer("e2e")
+
+	tiers := []string{"free", "silver", "gold", "gold", "free", "free"}
+	for _, tier := range tiers {
+		_, span := tr.Start(context.Background(), "op")
+		span.SetAttributes(attribute.String("customer.tier", tier))
+		span.End()
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("cd-svc", len(tiers))
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{
+			{"op": "count_distinct", "field": "customer.tier"},
+		},
+		"where": []map[string]any{{"field": "service.name", "op": "=", "value": "cd-svc"}},
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	distinct, _ := toInt64(res.Rows[0][res.columnIdx("count_distinct_customer_tier")])
+	if distinct != 3 {
+		t.Errorf("count_distinct: want 3, got %d", distinct)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HAVING: filter grouped rows on the aggregated value. Only buckets
+// with count >= N survive.
+// ---------------------------------------------------------------------------
+
+func TestE2E_HavingFilter(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("having-svc")
+	tr := tp.Tracer("e2e")
+
+	// 5 × GET, 3 × POST, 1 × DELETE.
+	mix := []struct {
+		method string
+		count  int
+	}{{"GET", 5}, {"POST", 3}, {"DELETE", 1}}
+	for _, m := range mix {
+		for i := 0; i < m.count; i++ {
+			_, span := tr.Start(context.Background(), "http.request")
+			span.SetAttributes(attribute.String("http.method", m.method))
+			span.End()
+		}
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("having-svc", 9)
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select":   []map[string]any{{"op": "count"}},
+		"where":    []map[string]any{{"field": "service.name", "op": "=", "value": "having-svc"}},
+		"group_by": []string{"http.method"},
+		"having": []map[string]any{
+			{"field": "count", "op": ">=", "value": 3},
+		},
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	// Only GET (5) and POST (3) should survive HAVING count >= 3.
+	got := map[string]int64{}
+	for _, row := range res.Rows {
+		m, _ := row[res.columnIdx("http_method")].(string)
+		c, _ := toInt64(row[res.columnIdx("count")])
+		got[m] = c
+	}
+	if got["GET"] != 5 || got["POST"] != 3 {
+		t.Errorf("want {GET:5, POST:3}, got %v", got)
+	}
+	if _, ok := got["DELETE"]; ok {
+		t.Errorf("DELETE should have been filtered out by HAVING: %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ORDER BY + LIMIT: top-N rows by count, descending.
+// ---------------------------------------------------------------------------
+
+func TestE2E_OrderByTopN(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("top-svc")
+	tr := tp.Tracer("e2e")
+
+	// Emit four distinct span names at different counts.
+	counts := map[string]int{"alpha": 8, "beta": 4, "gamma": 2, "delta": 1}
+	for name, n := range counts {
+		for i := 0; i < n; i++ {
+			_, span := tr.Start(context.Background(), name)
+			span.End()
+		}
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("top-svc", 15)
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select":   []map[string]any{{"op": "count"}},
+		"where":    []map[string]any{{"field": "service.name", "op": "=", "value": "top-svc"}},
+		"group_by": []string{"name"},
+		"order_by": []map[string]any{{"field": "count", "dir": "desc"}},
+		"limit":    2,
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(res.Rows) != 2 {
+		t.Fatalf("limit=2, got %d rows", len(res.Rows))
+	}
+	first := res.Rows[0][res.columnIdx("name")]
+	second := res.Rows[1][res.columnIdx("name")]
+	if first != "alpha" || second != "beta" {
+		t.Errorf("top-2 by count desc: want [alpha, beta], got [%v, %v]", first, second)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Time-window filter: ListTraces with from/to should only return spans
+// inside the window.
+// ---------------------------------------------------------------------------
+
+func TestE2E_TimeWindowFilter(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("tw-svc")
+	tr := tp.Tracer("e2e")
+
+	// Emit one span now; hold the timestamp.
+	_, span := tr.Start(context.Background(), "op")
+	span.End()
+	pivot := time.Now()
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("tw-svc", 1)
+
+	// A window that ends BEFORE pivot should return zero traces.
+	before := pivot.Add(-60 * time.Second)
+	url := fmt.Sprintf("/api/traces?service=tw-svc&from=%d&to=%d",
+		before.UnixNano(), pivot.Add(-30*time.Second).UnixNano())
+	var empty struct {
+		Traces []map[string]any `json:"traces"`
+	}
+	if err := f.getJSON(url, &empty); err != nil {
+		t.Fatalf("before-pivot query: %v", err)
+	}
+	if len(empty.Traces) != 0 {
+		t.Errorf("pre-pivot window should be empty, got %d", len(empty.Traces))
+	}
+
+	// A window around pivot should return exactly 1.
+	around := fmt.Sprintf("/api/traces?service=tw-svc&from=%d&to=%d",
+		pivot.Add(-60*time.Second).UnixNano(),
+		pivot.Add(60*time.Second).UnixNano())
+	var hit struct {
+		Traces []map[string]any `json:"traces"`
+	}
+	if err := f.getJSON(around, &hit); err != nil {
+		t.Fatalf("around-pivot query: %v", err)
+	}
+	if len(hit.Traces) != 1 {
+		t.Errorf("around-pivot window want 1 trace, got %d", len(hit.Traces))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pagination: ListTraces returns a cursor; fetching the next page yields
+// the remaining traces with no overlap.
+// ---------------------------------------------------------------------------
+
+func TestE2E_ListTracesPagination(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("page-svc")
+	tr := tp.Tracer("e2e")
+
+	// 30 independent traces. A small sleep between each one keeps their
+	// start_time_ns values strictly unique — the cursor the ListTraces
+	// endpoint hands out is just that timestamp, so two traces sharing
+	// one would cause a page boundary to skip a row. If / when the store
+	// composes a tie-breaker into the cursor (e.g. trace_id), this sleep
+	// can go.
+	const total = 30
+	for i := 0; i < total; i++ {
+		_, span := tr.Start(context.Background(), "op", trace.WithNewRoot())
+		span.End()
+		time.Sleep(200 * time.Microsecond)
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("page-svc", total)
+
+	seen := map[string]struct{}{}
+	cursor := ""
+	pages := 0
+	for {
+		pages++
+		if pages > 10 {
+			t.Fatal("paged more than 10 times, suspected infinite loop")
+		}
+		url := "/api/traces?service=page-svc&limit=10"
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		var page struct {
+			Traces []struct {
+				TraceID string `json:"trace_id"`
+			} `json:"traces"`
+			NextCursor string `json:"next_cursor"`
+		}
+		if err := f.getJSON(url, &page); err != nil {
+			t.Fatalf("page %d: %v", pages, err)
+		}
+		for _, tr := range page.Traces {
+			if _, dup := seen[tr.TraceID]; dup {
+				t.Fatalf("trace %s appeared on two pages", tr.TraceID)
+			}
+			seen[tr.TraceID] = struct{}{}
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	if len(seen) != total {
+		t.Errorf("paginated total: want %d, got %d", total, len(seen))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bucketed count: time-series rollup with group_by (none), bucket_ms set.
+// ---------------------------------------------------------------------------
+
+func TestE2E_BucketedCount(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("bucket-svc")
+	tr := tp.Tracer("e2e")
+
+	// 5 spans, clustered in time.
+	for i := 0; i < 5; i++ {
+		_, span := tr.Start(context.Background(), "op")
+		span.End()
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("bucket-svc", 5)
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select":    []map[string]any{{"op": "count"}},
+		"where":     []map[string]any{{"field": "service.name", "op": "=", "value": "bucket-svc"}},
+		"bucket_ms": 60_000,
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	// The bucket column should be present; summing counts across buckets
+	// should equal the total span count.
+	if res.columnIdx("bucket_ns") < 0 && res.columnIdx("bucket") < 0 {
+		t.Errorf("expected a bucket_ns / bucket column, got %+v", res.Columns)
+	}
+	var sum int64
+	countIdx := res.columnIdx("count")
+	for _, row := range res.Rows {
+		c, _ := toInt64(row[countIdx])
+		sum += c
+	}
+	if sum != 5 {
+		t.Errorf("bucketed counts should sum to 5, got %d", sum)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int64:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	}
+	return 0, false
+}

--- a/internal/ingest/e2e_spans_test.go
+++ b/internal/ingest/e2e_spans_test.go
@@ -1,0 +1,522 @@
+package ingest_test
+
+// SDK-driven span edge cases. Every test here emits via the real OTel Go
+// SDK, lets it pipeline through the OTLP/HTTP exporter into waggle's
+// ingest handler + SQLite writer, and then asserts on the public /api/*
+// surface. The goal is to exercise parts of the OTel data model that the
+// older sdk_integration_test doesn't touch.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ---------------------------------------------------------------------------
+// Span kinds: all five OTel SpanKind values should land in the store with
+// their numeric codes preserved and be addressable via `group_by: ["kind"]`.
+// ---------------------------------------------------------------------------
+
+func TestE2E_SpanKinds(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("kinds-svc")
+	tr := tp.Tracer("e2e")
+
+	kinds := []struct {
+		name string
+		kind trace.SpanKind
+	}{
+		{"internal", trace.SpanKindInternal},
+		{"server", trace.SpanKindServer},
+		{"client", trace.SpanKindClient},
+		{"producer", trace.SpanKindProducer},
+		{"consumer", trace.SpanKindConsumer},
+	}
+	for _, k := range kinds {
+		_, span := tr.Start(context.Background(), "op."+k.name, trace.WithSpanKind(k.kind))
+		span.End()
+	}
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("kinds-svc", len(kinds))
+
+	// Group-by kind + count — one row per kind, count=1 each.
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select":   []map[string]any{{"op": "count"}},
+		"where":    []map[string]any{{"field": "service.name", "op": "=", "value": "kinds-svc"}},
+		"group_by": []string{"kind"},
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	kindIdx := res.columnIdx("kind")
+	countIdx := res.columnIdx("count")
+	if kindIdx < 0 || countIdx < 0 {
+		t.Fatalf("missing columns in result: %+v", res.Columns)
+	}
+	got := map[int64]int64{}
+	for _, row := range res.Rows {
+		k, _ := toInt64(row[kindIdx])
+		c, _ := toInt64(row[countIdx])
+		got[k] = c
+	}
+	// OTel SpanKind ints: 0=unspecified, 1=internal, 2=server, 3=client, 4=producer, 5=consumer.
+	want := map[int64]int64{1: 1, 2: 1, 3: 1, 4: 1, 5: 1}
+	if !equalIntMap(want, got) {
+		t.Errorf("kind distribution: want %v, got %v", want, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Span status: three values (unset / ok / error). Error flows through
+// both `status_code=2` and the synthetic `error` field.
+// ---------------------------------------------------------------------------
+
+func TestE2E_SpanStatus(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("status-svc")
+	tr := tp.Tracer("e2e")
+
+	// Unset
+	_, s1 := tr.Start(context.Background(), "unset.op")
+	s1.End()
+	// Ok
+	_, s2 := tr.Start(context.Background(), "ok.op")
+	s2.SetStatus(codes.Ok, "")
+	s2.End()
+	// Error (status only, no exception event)
+	_, s3 := tr.Start(context.Background(), "error.op")
+	s3.SetStatus(codes.Error, "boom")
+	s3.End()
+	// Error via exception event only (status stays unset) — the synthetic
+	// `error` field should still fire.
+	_, s4 := tr.Start(context.Background(), "exception.op")
+	s4.AddEvent("exception", trace.WithAttributes(attribute.String("exception.type", "Oops")))
+	s4.End()
+
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("status-svc", 4)
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	// Error count via synthetic field: should be 2 (error.op + exception.op).
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select": []map[string]any{{"op": "count"}},
+		"where": []map[string]any{
+			{"field": "service.name", "op": "=", "value": "status-svc"},
+			{"field": "error", "op": "=", "value": true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("error-count query: %v", err)
+	}
+	count, _ := toInt64(res.Rows[0][res.columnIdx("count")])
+	if count != 2 {
+		t.Errorf("expected 2 error-flagged spans, got %d", count)
+	}
+
+	// Group-by status_code — 3 distinct rows (0=unset×2, 1=ok, 2=error).
+	res, err = f.runQueryAPI(map[string]any{
+		"dataset": "spans",
+		"time_range": map[string]any{
+			"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+		},
+		"select":   []map[string]any{{"op": "count"}},
+		"where":    []map[string]any{{"field": "service.name", "op": "=", "value": "status-svc"}},
+		"group_by": []string{"status_code"},
+	})
+	if err != nil {
+		t.Fatalf("status group-by query: %v", err)
+	}
+	perStatus := map[int64]int64{}
+	for _, row := range res.Rows {
+		k, _ := toInt64(row[res.columnIdx("status_code")])
+		c, _ := toInt64(row[res.columnIdx("count")])
+		perStatus[k] = c
+	}
+	// Exactly one Ok span and one Error span; the two exception+unset
+	// spans share status 0 so that bucket has count=2.
+	if perStatus[0] != 2 || perStatus[1] != 1 || perStatus[2] != 1 {
+		t.Errorf("status distribution: want {0:2, 1:1, 2:1}, got %v", perStatus)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Events: multiple events per span, each with their own attributes, must
+// round-trip through the GetTrace handler.
+// ---------------------------------------------------------------------------
+
+func TestE2E_SpanEvents(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("events-svc")
+	tr := tp.Tracer("e2e")
+
+	_, span := tr.Start(context.Background(), "op.with.events")
+	span.AddEvent("cache.lookup", trace.WithAttributes(
+		attribute.Bool("cache.hit", true),
+		attribute.String("cache.key", "sessions:42"),
+	))
+	span.AddEvent("db.query", trace.WithAttributes(
+		attribute.String("db.statement", "SELECT 1"),
+		attribute.Int("db.rows", 1),
+	))
+	span.AddEvent("done")
+	span.End()
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("events-svc", 1)
+
+	// Find the trace and pull its detail.
+	var listResp struct {
+		Traces []struct {
+			TraceID string `json:"trace_id"`
+		} `json:"traces"`
+	}
+	if err := f.getJSON("/api/traces?service=events-svc&limit=5", &listResp); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(listResp.Traces) == 0 {
+		t.Fatal("no trace returned")
+	}
+	var detail struct {
+		Spans []struct {
+			Name   string `json:"name"`
+			Events []struct {
+				Name       string `json:"name"`
+				Attributes string `json:"attributes"`
+			} `json:"events"`
+		} `json:"spans"`
+	}
+	if err := f.getJSON("/api/traces/"+listResp.Traces[0].TraceID, &detail); err != nil {
+		t.Fatalf("detail: %v", err)
+	}
+	if len(detail.Spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(detail.Spans))
+	}
+	evs := detail.Spans[0].Events
+	if len(evs) != 3 {
+		t.Fatalf("expected 3 events, got %d (%+v)", len(evs), evs)
+	}
+	names := make([]string, len(evs))
+	for i, e := range evs {
+		names[i] = e.Name
+	}
+	wantNames := []string{"cache.lookup", "db.query", "done"}
+	for i, n := range wantNames {
+		if names[i] != n {
+			t.Errorf("event[%d]: want %q, got %q (all: %v)", i, n, names[i], names)
+		}
+	}
+	// First event carries cache.hit=true and cache.key in its attributes.
+	if !strings.Contains(evs[0].Attributes, `"cache.hit":true`) ||
+		!strings.Contains(evs[0].Attributes, `"cache.key":"sessions:42"`) {
+		t.Errorf("event[0] attrs lost: %s", evs[0].Attributes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Links: a consumer span carrying a link back to a producer's span
+// context (the classic async / queue pattern). GetTrace should surface
+// the linked trace/span IDs.
+// ---------------------------------------------------------------------------
+
+func TestE2E_SpanLinks(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("linker-svc")
+	tr := tp.Tracer("e2e")
+
+	// Producer trace.
+	_, producer := tr.Start(context.Background(), "queue.publish",
+		trace.WithSpanKind(trace.SpanKindProducer))
+	producerSC := producer.SpanContext()
+	producer.End()
+
+	// Consumer trace: new root that links to the producer.
+	_, consumer := tr.Start(context.Background(), "queue.consume",
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithNewRoot(),
+		trace.WithLinks(trace.Link{
+			SpanContext: producerSC,
+			Attributes: []attribute.KeyValue{
+				attribute.String("messaging.operation", "receive"),
+			},
+		}),
+	)
+	consumerSID := consumer.SpanContext().SpanID().String()
+	consumerTID := consumer.SpanContext().TraceID().String()
+	consumer.End()
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("linker-svc", 2)
+
+	var detail struct {
+		Spans []struct {
+			SpanID string `json:"span_id"`
+			Links  []struct {
+				LinkedTraceID string `json:"linked_trace_id"`
+				LinkedSpanID  string `json:"linked_span_id"`
+				Attributes    string `json:"attributes"`
+			} `json:"links"`
+		} `json:"spans"`
+	}
+	if err := f.getJSON("/api/traces/"+consumerTID, &detail); err != nil {
+		t.Fatalf("detail: %v", err)
+	}
+	var consumerSpan *struct {
+		Links []struct {
+			LinkedTraceID string `json:"linked_trace_id"`
+			LinkedSpanID  string `json:"linked_span_id"`
+			Attributes    string `json:"attributes"`
+		} `json:"links"`
+	}
+	for i := range detail.Spans {
+		if detail.Spans[i].SpanID == consumerSID {
+			consumerSpan = &struct {
+				Links []struct {
+					LinkedTraceID string `json:"linked_trace_id"`
+					LinkedSpanID  string `json:"linked_span_id"`
+					Attributes    string `json:"attributes"`
+				} `json:"links"`
+			}{Links: detail.Spans[i].Links}
+			break
+		}
+	}
+	if consumerSpan == nil {
+		t.Fatalf("consumer span %s missing from trace detail", consumerSID)
+	}
+	if len(consumerSpan.Links) != 1 {
+		t.Fatalf("want 1 link, got %d", len(consumerSpan.Links))
+	}
+	link := consumerSpan.Links[0]
+	if !strings.EqualFold(link.LinkedTraceID, producerSC.TraceID().String()) {
+		t.Errorf("linked_trace_id: want %s, got %s",
+			producerSC.TraceID().String(), link.LinkedTraceID)
+	}
+	if !strings.EqualFold(link.LinkedSpanID, producerSC.SpanID().String()) {
+		t.Errorf("linked_span_id: want %s, got %s",
+			producerSC.SpanID().String(), link.LinkedSpanID)
+	}
+	if !strings.Contains(link.Attributes, `"messaging.operation":"receive"`) {
+		t.Errorf("link attrs missing: %s", link.Attributes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Attribute types: OTel supports string, int64, float64, bool, plus
+// slices of each. Every scalar type should survive the round-trip and be
+// filterable via /api/query.
+// ---------------------------------------------------------------------------
+
+func TestE2E_AttributeTypes(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	tp := f.tracerProvider("attrs-svc")
+	tr := tp.Tracer("e2e")
+
+	_, span := tr.Start(context.Background(), "typed.op")
+	span.SetAttributes(
+		attribute.String("attr.string", "hello"),
+		attribute.Int("attr.int", 42),
+		attribute.Int64("attr.int64", 1<<40),
+		attribute.Float64("attr.float", 3.14),
+		attribute.Bool("attr.bool", true),
+		attribute.StringSlice("attr.strslice", []string{"a", "b", "c"}),
+		attribute.IntSlice("attr.intslice", []int{1, 2, 3}),
+	)
+	span.End()
+	f.shutdownTracer(tp)
+	f.waitForSpanCount("attrs-svc", 1)
+
+	// Filter on each scalar type — all should match exactly one span.
+	cases := []struct {
+		name  string
+		op    string
+		value any
+	}{
+		{"attr.string", "=", "hello"},
+		{"attr.int", "=", 42},
+		{"attr.int64", ">=", int64(1 << 40)},
+		{"attr.float", ">=", 3.0},
+		{"attr.bool", "=", true},
+	}
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, err := f.runQueryAPI(map[string]any{
+				"dataset": "spans",
+				"time_range": map[string]any{
+					"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second)),
+				},
+				"select": []map[string]any{{"op": "count"}},
+				"where": []map[string]any{
+					{"field": "service.name", "op": "=", "value": "attrs-svc"},
+					{"field": c.name, "op": c.op, "value": c.value},
+				},
+			})
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			count, _ := toInt64(res.Rows[0][res.columnIdx("count")])
+			if count != 1 {
+				t.Errorf("filter on %s %s %v: want 1, got %d", c.name, c.op, c.value, count)
+			}
+		})
+	}
+
+	// Slice attributes don't filter via =, but they must appear in the
+	// raw span attributes blob on GetTrace. Fetch the one span.
+	var listResp struct {
+		Traces []struct {
+			TraceID string `json:"trace_id"`
+		} `json:"traces"`
+	}
+	if err := f.getJSON("/api/traces?service=attrs-svc&limit=5", &listResp); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(listResp.Traces) == 0 {
+		t.Fatal("no trace")
+	}
+	var detail struct {
+		Spans []struct {
+			Attributes string `json:"attributes"`
+		} `json:"spans"`
+	}
+	if err := f.getJSON("/api/traces/"+listResp.Traces[0].TraceID, &detail); err != nil {
+		t.Fatalf("detail: %v", err)
+	}
+	attrs := detail.Spans[0].Attributes
+	for _, frag := range []string{
+		`"attr.strslice":["a","b","c"]`,
+		`"attr.intslice":[1,2,3]`,
+	} {
+		if !strings.Contains(attrs, frag) {
+			t.Errorf("missing %s in attrs: %s", frag, attrs)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parent/child + cross-service: a single trace_id spanning 2 services
+// composes into one trace on GetTrace with all spans present.
+// ---------------------------------------------------------------------------
+
+func TestE2E_CrossServiceTrace(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	apiTP := f.tracerProvider("gateway")
+	payTP := f.tracerProvider("payments")
+	apiTracer := apiTP.Tracer("e2e")
+	payTracer := payTP.Tracer("e2e")
+
+	ctx, root := apiTracer.Start(context.Background(), "POST /checkout",
+		trace.WithSpanKind(trace.SpanKindServer))
+	traceID := root.SpanContext().TraceID().String()
+
+	// Child on the OTHER service but inheriting the same trace_id via ctx.
+	_, child := payTracer.Start(ctx, "PaymentService/Authorize",
+		trace.WithSpanKind(trace.SpanKindClient))
+	child.End()
+	root.End()
+
+	f.shutdownTracer(apiTP)
+	f.shutdownTracer(payTP)
+	f.waitForTotalSpanCount(2)
+
+	var detail struct {
+		Spans []struct {
+			ServiceName string `json:"service_name"`
+			Name        string `json:"name"`
+		} `json:"spans"`
+	}
+	if err := f.getJSON("/api/traces/"+traceID, &detail); err != nil {
+		t.Fatalf("detail: %v", err)
+	}
+	if len(detail.Spans) != 2 {
+		t.Fatalf("cross-service trace: want 2 spans, got %d", len(detail.Spans))
+	}
+	got := map[string]string{}
+	for _, s := range detail.Spans {
+		got[s.ServiceName] = s.Name
+	}
+	if got["gateway"] != "POST /checkout" {
+		t.Errorf("gateway span missing / wrong: %v", got)
+	}
+	if got["payments"] != "PaymentService/Authorize" {
+		t.Errorf("payments span missing / wrong: %v", got)
+	}
+
+	// Service list must show both with span_count = 1 each.
+	var svcResp struct {
+		Services []struct {
+			Service   string `json:"service"`
+			SpanCount int64  `json:"span_count"`
+		} `json:"services"`
+	}
+	if err := f.getJSON("/api/services", &svcResp); err != nil {
+		t.Fatalf("services: %v", err)
+	}
+	per := map[string]int64{}
+	for _, s := range svcResp.Services {
+		per[s.Service] = s.SpanCount
+	}
+	if per["gateway"] != 1 || per["payments"] != 1 {
+		t.Errorf("service counts want gateway=1 payments=1, got %v", per)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers shared by span tests
+// ---------------------------------------------------------------------------
+
+func toInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case float64:
+		return int64(n), true
+	case string:
+		var x int64
+		if _, err := fmt.Sscan(n, &x); err == nil {
+			return x, true
+		}
+	}
+	return 0, false
+}
+
+func equalIntMap(a, b map[int64]int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Adds 27 end-to-end tests that drive real OTel Go SDK emissions through the full server shape and then assert against the \`/api/*\` surface — the shape the UI actually consumes. Same process that kept turning up latent bugs during this last stretch, now automated.

### Fixture (\`e2e_fixture_test.go\`)

Single \`httptest.Server\` mounting both \`/v1/{traces,logs}\` and \`/api/*\` against a temp-dir SQLite store. Helpers:
- \`tracerProvider(svc)\` / \`loggerProvider(svc)\` — real OTLP/HTTP exporters pointed at the fixture.
- \`waitForSpanCount\` / \`waitForLogCount\` — poll until ingest catches up.
- \`runQueryAPI\` — POSTs \`/api/query\` with a typed result struct + \`columnIdx\` helper.

### Coverage

**Spans (\`e2e_spans_test.go\`)**
- All 5 \`SpanKind\` values group-by correctly
- \`SpanStatus\` Unset/Ok/Error + synthetic \`error\` firing on both status=Error AND exception events
- Multi-event spans with per-event attributes
- Links across traces (producer / consumer) with linked IDs + attributes
- Every attribute scalar type (string, int, int64, float, bool) + slices
- Cross-service trace_id sharing composed into one trace

**Logs (\`e2e_logs_test.go\`)**
- TRACE..FATAL severity spectrum + synthetic \`error\` at sev >= 17
- Automatic trace_id/span_id stamping inside an active span ctx
- Structured map bodies round-tripping as JSON
- Attribute-level WHERE filtering
- \`body contains X\` substring filter

**Queries (\`e2e_query_test.go\`)**
- AVG/MIN/MAX/SUM/COUNT over real durations
- p50 / p95 / p99 banding across a fast/slow mix
- COUNT_DISTINCT on a JSONB attribute
- HAVING, ORDER BY + LIMIT top-N
- Time-window filter, cursor pagination, bucket_ms rollup

**Ops / catalogue (\`e2e_ops_test.go\`)**
- \`POST /api/clear\` empties the store
- \`store.Retain()\` drops pre-cutoff data
- \`/api/fields\` returns synthetic + JSONB keys with correct service scoping
- \`/api/fields/{key}/values\`, \`/api/span-names\`, \`has_error\` filter
- \`/api/query\` 400 on invalid ops; \`/v1/traces\` 400 on garbage + 415 on bogus content-type

## Branch protection

Enabled on \`main\` at the same time as opening this PR:
- Required status check: **test** (\`go test ./...\` in the CI workflow)
- Strict: branch must be up-to-date with main before merge
- No force pushes, no branch deletion

From now on a PR can't merge if these tests fail, which is exactly what this suite is designed to prevent.

## Notes for follow-up

- ListTraces cursor uses \`start_time_ns\` only; two traces sharing the same timestamp cause a page boundary to skip one. The pagination test works around this with a 200µs sleep between emissions — filed as a comment in the test. Proper fix is composing \`(start_time_ns, trace_id)\` into the cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)