### PR TITLE
fix(store): composite cursors break ties deterministically

### DIFF
--- a/internal/ingest/e2e_query_test.go
+++ b/internal/ingest/e2e_query_test.go
@@ -346,17 +346,15 @@ func TestE2E_ListTracesPagination(t *testing.T) {
 	tp := f.tracerProvider("page-svc")
 	tr := tp.Tracer("e2e")
 
-	// 30 independent traces. A small sleep between each one keeps their
-	// start_time_ns values strictly unique — the cursor the ListTraces
-	// endpoint hands out is just that timestamp, so two traces sharing
-	// one would cause a page boundary to skip a row. If / when the store
-	// composes a tie-breaker into the cursor (e.g. trace_id), this sleep
-	// can go.
+	// 30 independent traces emitted in a tight loop — deliberately no
+	// sleep between them, so several will share a start_time_ns at
+	// microsecond resolution. The cursor must compose a tie-breaker
+	// (trace_id) so none of those tied rows are skipped at a page
+	// boundary.
 	const total = 30
 	for i := 0; i < total; i++ {
 		_, span := tr.Start(context.Background(), "op", trace.WithNewRoot())
 		span.End()
-		time.Sleep(200 * time.Microsecond)
 	}
 	f.shutdownTracer(tp)
 	f.waitForSpanCount("page-svc", total)

--- a/internal/store/sqlite/queries.go
+++ b/internal/store/sqlite/queries.go
@@ -291,19 +291,20 @@ func (s *Store) ListTraces(ctx context.Context, f store.TraceFilter) ([]store.Tr
 		b.WriteString(" AND start_time_ns < ?")
 		args = append(args, f.ToNS)
 	}
-	if f.Cursor != "" {
-		cursorNS, err := strconv.ParseInt(f.Cursor, 10, 64)
-		if err == nil {
-			b.WriteString(" AND start_time_ns < ?")
-			args = append(args, cursorNS)
+	if cursorNS, tidHex, ok := parseCompositeCursor(f.Cursor); ok {
+		// Composite cursor with trace_id as the tie-breaker — no row is
+		// ever skipped when multiple roots share start_time_ns.
+		if tid, err := hex.DecodeString(tidHex); err == nil {
+			b.WriteString(" AND (start_time_ns < ? OR (start_time_ns = ? AND trace_id < ?))")
+			args = append(args, cursorNS, cursorNS, tid)
 		}
 	}
-	b.WriteString(` ORDER BY start_time_ns DESC LIMIT ?)
+	b.WriteString(` ORDER BY start_time_ns DESC, trace_id DESC LIMIT ?)
 		SELECT r.trace_id, r.service_name, r.name, r.start_time_ns,
 		  (r.end_time_ns - r.start_time_ns) AS duration_ns,
 		  (SELECT COUNT(*) FROM spans s WHERE s.trace_id = r.trace_id) AS span_count,
 		  COALESCE((SELECT 1 FROM spans s WHERE s.trace_id = r.trace_id AND s.status_code = 2 LIMIT 1), 0) AS has_error
-		FROM roots r ORDER BY r.start_time_ns DESC`)
+		FROM roots r ORDER BY r.start_time_ns DESC, r.trace_id DESC`)
 	args = append(args, limit)
 
 	if f.HasError != nil {
@@ -345,9 +346,34 @@ func (s *Store) ListTraces(ctx context.Context, f store.TraceFilter) ([]store.Tr
 
 	cursor := ""
 	if len(out) == limit {
-		cursor = strconv.FormatInt(out[len(out)-1].StartTimeNS, 10)
+		last := out[len(out)-1]
+		cursor = encodeCompositeCursor(last.StartTimeNS, last.TraceID)
 	}
 	return out, cursor, nil
+}
+
+// parseCompositeCursor decodes a "primary:secondary" cursor. Primary is
+// always an int64 timestamp; secondary is a free-form string tag (hex
+// trace_id for traces, log_id for logs). Malformed cursors are ignored
+// (ok=false) so the caller treats it as no cursor and returns the first
+// page — same as an empty string.
+func parseCompositeCursor(s string) (primary int64, secondary string, ok bool) {
+	if s == "" {
+		return 0, "", false
+	}
+	primStr, sec, found := strings.Cut(s, ":")
+	if !found || sec == "" {
+		return 0, "", false
+	}
+	n, err := strconv.ParseInt(primStr, 10, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	return n, sec, true
+}
+
+func encodeCompositeCursor(primary int64, secondary string) string {
+	return strconv.FormatInt(primary, 10) + ":" + secondary
 }
 
 func (s *Store) GetTrace(ctx context.Context, traceIDHex string) (store.TraceDetail, error) {
@@ -812,20 +838,22 @@ func (s *Store) SearchLogs(ctx context.Context, f store.LogFilter) ([]store.LogO
 		}
 		args = append(args, f.ToNS)
 	}
-	if f.Cursor != "" {
-		if cursorNS, err := strconv.ParseInt(f.Cursor, 10, 64); err == nil {
+	if cursorNS, logIDStr, ok := parseCompositeCursor(f.Cursor); ok {
+		if logID, err := strconv.ParseInt(logIDStr, 10, 64); err == nil {
+			logIDCol := "log_id"
+			timeCol := "time_ns"
 			if f.Query != "" {
-				b.WriteString(" AND l.time_ns < ?")
-			} else {
-				b.WriteString(" AND time_ns < ?")
+				logIDCol = "l.log_id"
+				timeCol = "l.time_ns"
 			}
-			args = append(args, cursorNS)
+			fmt.Fprintf(&b, " AND (%s < ? OR (%s = ? AND %s < ?))", timeCol, timeCol, logIDCol)
+			args = append(args, cursorNS, cursorNS, logID)
 		}
 	}
 	if f.Query != "" {
-		b.WriteString(" ORDER BY l.time_ns DESC LIMIT ?")
+		b.WriteString(" ORDER BY l.time_ns DESC, l.log_id DESC LIMIT ?")
 	} else {
-		b.WriteString(" ORDER BY time_ns DESC LIMIT ?")
+		b.WriteString(" ORDER BY time_ns DESC, log_id DESC LIMIT ?")
 	}
 	args = append(args, limit)
 
@@ -861,7 +889,8 @@ func (s *Store) SearchLogs(ctx context.Context, f store.LogFilter) ([]store.LogO
 
 	cursor := ""
 	if len(out) == limit {
-		cursor = strconv.FormatInt(out[len(out)-1].TimeNS, 10)
+		last := out[len(out)-1]
+		cursor = encodeCompositeCursor(last.TimeNS, strconv.FormatInt(last.LogID, 10))
 	}
 	return out, cursor, nil
 }


### PR DESCRIPTION
## The bug

Both paginated endpoints carried only a timestamp in \`next_cursor\`. Two rows sharing it landed on opposite sides of a page boundary and the row at the boundary got dropped — the next page's \`primary_ts < last_seen\` is strict.

Trivially reproducible in the E2E pagination test: 30 traces emitted in a tight loop returned 29. The test had been papering over it with a 200µs sleep per emission; that's gone now, and the test exercises the tie case deliberately.

## The fix

- \`ListTraces\` cursor → \`\"start_time_ns:trace_id_hex\"\`
- \`SearchLogs\` cursor → \`\"time_ns:log_id\"\`
- \`ORDER BY\` grew the tie-breaker on both endpoints so the result set is totally ordered.
- Cursor WHERE predicate becomes \`primary < ? OR (primary = ? AND secondary < ?)\` — strict tuple less-than matching the sort.
- New \`parseCompositeCursor\` / \`encodeCompositeCursor\` helpers keep the two endpoints' cursor shapes consistent.
- Cursor parsing is strict: a bare integer (or anything without a \`:secondary\`) is rejected and the caller returns the first page, same as an empty cursor. No pre-fix shared URL exists we'd be breaking.

## Test plan

- [x] \`go test ./...\` — the existing pagination E2E test now runs without the 200µs workaround sleep and still passes 30/30.
- [x] \`go vet ./...\`
- [ ] CI picks this up via the required \`test\` status check set up alongside PR #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)