### PR TITLE
feat(metrics): stage 2 — query engine + /api/metrics endpoints

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -30,6 +30,8 @@ func (rt *Router) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/fields/{key}/values", rt.listFieldValues)
 	mux.HandleFunc("GET /api/span-names", rt.listSpanNames)
 	mux.HandleFunc("GET /api/logs/search", rt.searchLogs)
+	mux.HandleFunc("GET /api/metrics", rt.listMetrics)
+	mux.HandleFunc("GET /api/metrics/{name}/series", rt.listMetricSeries)
 	mux.HandleFunc("POST /api/query", rt.runQuery)
 	mux.HandleFunc("POST /api/clear", rt.clear)
 }
@@ -202,6 +204,34 @@ func (rt *Router) clear(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+func (rt *Router) listMetrics(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	metrics, err := rt.store.ListMetrics(r.Context(), store.MetricFilter{
+		Service: q.Get("service"),
+		Prefix:  q.Get("prefix"),
+		Limit:   parseInt(q.Get("limit"), 200),
+	})
+	if err != nil {
+		rt.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"metrics": metrics})
+}
+
+func (rt *Router) listMetricSeries(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	series, err := rt.store.ListMetricSeries(r.Context(), store.MetricSeriesFilter{
+		Name:    r.PathValue("name"),
+		Service: q.Get("service"),
+		Limit:   parseInt(q.Get("limit"), 200),
+	})
+	if err != nil {
+		rt.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"series": series})
 }
 
 func (rt *Router) writeError(w http.ResponseWriter, err error) {

--- a/internal/ingest/e2e_metrics_test.go
+++ b/internal/ingest/e2e_metrics_test.go
@@ -333,3 +333,169 @@ func indexString(s, sub string) int {
 	}
 	return -1
 }
+
+// ---------------------------------------------------------------------------
+// /api/metrics + /api/metrics/{name}/series
+// ---------------------------------------------------------------------------
+
+func TestE2E_MetricsAPIListing(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	mp := f.meterProvider("picker-svc")
+	meter := mp.Meter("e2e")
+
+	reqs, _ := meter.Int64Counter("requests.total", metric.WithUnit("1"),
+		metric.WithDescription("total HTTP requests"))
+	reqs.Add(context.Background(), 1, metric.WithAttributes(attribute.String("route", "/a")))
+	reqs.Add(context.Background(), 1, metric.WithAttributes(attribute.String("route", "/b")))
+
+	_, err := meter.Float64ObservableGauge("memory.used", metric.WithUnit("By"),
+		metric.WithFloat64Callback(func(_ context.Context, obs metric.Float64Observer) error {
+			obs.Observe(1024)
+			return nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(250 * time.Millisecond)
+	f.shutdownMeter(mp)
+	f.waitForMetricSeries("picker-svc", 3) // 2 routes on requests + 1 gauge
+
+	var listing struct {
+		Metrics []struct {
+			Name        string `json:"name"`
+			Kind        string `json:"kind"`
+			Unit        string `json:"unit"`
+			Description string `json:"description"`
+			SeriesCount int64  `json:"series_count"`
+		} `json:"metrics"`
+	}
+	if err := f.getJSON("/api/metrics?service=picker-svc", &listing); err != nil {
+		t.Fatalf("GET /api/metrics: %v", err)
+	}
+	byName := map[string]struct {
+		Kind        string
+		Unit        string
+		Count       int64
+	}{}
+	for _, m := range listing.Metrics {
+		byName[m.Name] = struct {
+			Kind  string
+			Unit  string
+			Count int64
+		}{m.Kind, m.Unit, m.SeriesCount}
+	}
+	if e := byName["requests.total"]; e.Kind != "sum" || e.Count != 2 {
+		t.Errorf("requests.total: want sum / series_count=2, got %+v", e)
+	}
+	if e := byName["memory.used"]; e.Kind != "gauge" || e.Unit != "By" {
+		t.Errorf("memory.used: want gauge unit=By, got %+v", e)
+	}
+
+	// /api/metrics/{name}/series
+	var series struct {
+		Series []struct {
+			SeriesID    int64  `json:"series_id"`
+			ServiceName string `json:"service_name"`
+			Kind        string `json:"kind"`
+			Attributes  string `json:"attributes"`
+		} `json:"series"`
+	}
+	if err := f.getJSON("/api/metrics/requests.total/series?service=picker-svc", &series); err != nil {
+		t.Fatalf("series endpoint: %v", err)
+	}
+	if len(series.Series) != 2 {
+		t.Fatalf("want 2 series, got %d (%+v)", len(series.Series), series.Series)
+	}
+	for _, s := range series.Series {
+		if s.Kind != "sum" {
+			t.Errorf("series kind: want sum, got %q", s.Kind)
+		}
+		if s.ServiceName != "picker-svc" {
+			t.Errorf("service_name: want picker-svc, got %q", s.ServiceName)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// /api/query with dataset=metrics — the shared query path works
+// against the metric_points + metric_series join.
+// ---------------------------------------------------------------------------
+
+func TestE2E_MetricsQuery(t *testing.T) {
+	f := newE2EFixture(t)
+	defer f.close()
+
+	mp := f.meterProvider("q-svc")
+	counter, err := mp.Meter("e2e").Int64Counter("events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("k", "a")))
+	}
+	for i := 0; i < 3; i++ {
+		counter.Add(context.Background(), 1, metric.WithAttributes(attribute.String("k", "b")))
+	}
+	f.shutdownMeter(mp)
+	f.waitForMetricSeries("q-svc", 2)
+	f.waitForMetricPoints("q-svc", "events", 2)
+
+	now := time.Now()
+	from := now.Add(-5 * time.Minute)
+
+	// Aggregated MAX(value) group-by k — cumulative sum instruments
+	// report their total-to-date, so MAX over a window reflects the
+	// last-seen cumulative level per series. Should equal the total
+	// we added.
+	res, err := f.runQueryAPI(map[string]any{
+		"dataset":    "metrics",
+		"time_range": map[string]any{"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second))},
+		"select":     []map[string]any{{"op": "max", "field": "value"}},
+		"where": []map[string]any{
+			{"field": "service.name", "op": "=", "value": "q-svc"},
+			{"field": "name", "op": "=", "value": "events"},
+		},
+		"group_by": []string{"k"},
+	})
+	if err != nil {
+		t.Fatalf("metrics query: %v", err)
+	}
+	got := map[string]float64{}
+	kIdx := res.columnIdx("k")
+	maxIdx := res.columnIdx("max_value")
+	for _, row := range res.Rows {
+		key, _ := row[kIdx].(string)
+		v, _ := toFloat(row[maxIdx])
+		got[key] = v
+	}
+	if got["a"] != 5 {
+		t.Errorf("max(value) where k=a: want 5, got %v", got["a"])
+	}
+	if got["b"] != 3 {
+		t.Errorf("max(value) where k=b: want 3, got %v", got["b"])
+	}
+
+	// Raw-rows mode (empty SELECT) — each point comes back with
+	// service_name, name, kind, value, and the series attributes blob.
+	rawRes, err := f.runQueryAPI(map[string]any{
+		"dataset":    "metrics",
+		"time_range": map[string]any{"from": rfc3339(from), "to": rfc3339(now.Add(5 * time.Second))},
+		"select":     []map[string]any{},
+		"where":      []map[string]any{{"field": "service.name", "op": "=", "value": "q-svc"}},
+		"limit":      50,
+	})
+	if err != nil {
+		t.Fatalf("raw metrics query: %v", err)
+	}
+	if len(rawRes.Rows) == 0 {
+		t.Fatal("raw metrics query returned no rows")
+	}
+	// Expect the five shape columns documented in rawColumnsFor.
+	for _, c := range []string{"time_ns", "service_name", "name", "kind", "value", "attributes"} {
+		if rawRes.columnIdx(c) < 0 {
+			t.Errorf("raw metric columns missing %q (got %+v)", c, rawRes.Columns)
+		}
+	}
+}

--- a/internal/query/builder.go
+++ b/internal/query/builder.go
@@ -56,7 +56,7 @@ func (b *builder) buildRaw() (Compiled, error) {
 	sql.WriteString("SELECT ")
 	sql.WriteString(strings.Join(b.selects, ", "))
 	sql.WriteString(" FROM ")
-	sql.WriteString(string(b.q.Dataset))
+	sql.WriteString(b.datasetFromClause())
 	sql.WriteString(" WHERE ")
 	sql.WriteString(strings.Join(whereParts, " AND "))
 
@@ -97,6 +97,24 @@ func (b *builder) buildRaw() (Compiled, error) {
 // positional output into typed rows.
 func rawColumnsFor(d Dataset) ([]Column, []string) {
 	switch d {
+	case DatasetMetrics:
+		cols := []Column{
+			{Name: "time_ns", Type: "time"},
+			{Name: "service_name", Type: "string"},
+			{Name: "name", Type: "string"},
+			{Name: "kind", Type: "string"},
+			{Name: "value", Type: "float"},
+			{Name: "attributes", Type: "string"},
+		}
+		exprs := []string{
+			"p.time_ns",
+			"s.service_name",
+			"s.name",
+			"s.kind",
+			"p.value",
+			"s.attributes",
+		}
+		return cols, exprs
 	case DatasetLogs:
 		cols := []Column{
 			{Name: "time_ns", Type: "time"},
@@ -270,7 +288,7 @@ func (b *builder) build() (Compiled, error) {
 	sql.WriteString("SELECT ")
 	sql.WriteString(strings.Join(b.selects, ", "))
 	sql.WriteString(" FROM ")
-	sql.WriteString(string(b.q.Dataset))
+	sql.WriteString(b.datasetFromClause())
 	sql.WriteString(" WHERE ")
 	sql.WriteString(strings.Join(whereParts, " AND "))
 
@@ -354,7 +372,7 @@ func (b *builder) resolveField(name string) (resolvedField, error) {
 	// the path; use a literal to keep the expression deterministic.
 	path := fmt.Sprintf(`'$."%s"'`, name)
 	return resolvedField{
-		SQL:  fmt.Sprintf("json_extract(attributes, %s)", path),
+		SQL:  fmt.Sprintf("json_extract(%s, %s)", b.attributesColumn(), path),
 		Type: "string",
 	}, nil
 }
@@ -431,15 +449,67 @@ func (b *builder) realColumn(name string) (resolvedField, bool) {
 			// ≥ 17 per OTel log data model).
 			return resolvedField{SQL: "(severity_number >= 17)", Type: "bool"}, true
 		}
+	case DatasetMetrics:
+		// Metric queries join metric_points (p) to metric_series (s);
+		// point-level fields live on p, series-level facets on s.
+		switch name {
+		case "name":
+			return resolvedField{SQL: "s.name", Type: "string"}, true
+		case "service.name":
+			return resolvedField{SQL: "s.service_name", Type: "string"}, true
+		case "kind":
+			return resolvedField{SQL: "s.kind", Type: "string"}, true
+		case "unit":
+			return resolvedField{SQL: "s.unit", Type: "string"}, true
+		case "temporality":
+			return resolvedField{SQL: "s.temporality", Type: "string"}, true
+		case "value":
+			return resolvedField{SQL: "p.value", Type: "float"}, true
+		case "time_ns":
+			return resolvedField{SQL: "p.time_ns", Type: "time"}, true
+		case "start_time_ns":
+			return resolvedField{SQL: "p.start_time_ns", Type: "time"}, true
+		case "series_id":
+			return resolvedField{SQL: "p.series_id", Type: "int"}, true
+		}
 	}
 	return resolvedField{}, false
 }
 
 func (b *builder) datasetTimeColumn() string {
-	if b.q.Dataset == DatasetLogs {
+	switch b.q.Dataset {
+	case DatasetLogs:
 		return "time_ns"
+	case DatasetMetrics:
+		// Points live on metric_points; attributes on metric_series (see
+		// datasetFromClause). Time qualifier matches the aliased point
+		// table so the planner picks idx_metric_points_time.
+		return "p.time_ns"
 	}
 	return "start_time_ns"
+}
+
+// datasetFromClause returns the table expression for the FROM clause.
+// Spans + logs are single-table; metrics JOIN points to series so the
+// same attribute-key autocomplete and series-metadata columns resolve
+// like any other field.
+func (b *builder) datasetFromClause() string {
+	switch b.q.Dataset {
+	case DatasetMetrics:
+		return "metric_points p JOIN metric_series s ON s.series_id = p.series_id"
+	default:
+		return string(b.q.Dataset)
+	}
+}
+
+// attributesColumn is the SQL expression used as the first argument to
+// json_extract for attribute-key fallbacks. For metrics the attributes
+// live on the series, not the point, so the qualified alias is needed.
+func (b *builder) attributesColumn() string {
+	if b.q.Dataset == DatasetMetrics {
+		return "s.attributes"
+	}
+	return "attributes"
 }
 
 func (b *builder) aggregation(a Aggregation) (string, string, error) {

--- a/internal/query/builder_test.go
+++ b/internal/query/builder_test.go
@@ -20,7 +20,7 @@ func TestValidate_RequiresDatasetAndSelect(t *testing.T) {
 		wantErr string
 	}{
 		{"missing dataset", Query{TimeRange: tr(), Select: []Aggregation{{Op: OpCount}}}, "dataset"},
-		{"invalid dataset", Query{Dataset: "metrics", TimeRange: tr(), Select: []Aggregation{{Op: OpCount}}}, "dataset"},
+		{"invalid dataset", Query{Dataset: "events", TimeRange: tr(), Select: []Aggregation{{Op: OpCount}}}, "dataset"},
 		{"missing time", Query{Dataset: DatasetSpans, Select: []Aggregation{{Op: OpCount}}}, "time_range"},
 		// "no selects" is now valid — it triggers raw-rows mode. Removed.
 		{"unknown op", Query{Dataset: DatasetSpans, TimeRange: tr(), Select: []Aggregation{{Op: "weird"}}}, "op"},

--- a/internal/query/types.go
+++ b/internal/query/types.go
@@ -18,8 +18,9 @@ import (
 type Dataset string
 
 const (
-	DatasetSpans Dataset = "spans"
-	DatasetLogs  Dataset = "logs"
+	DatasetSpans   Dataset = "spans"
+	DatasetLogs    Dataset = "logs"
+	DatasetMetrics Dataset = "metrics"
 )
 
 // Query is the wire-level structured query.

--- a/internal/query/validate.go
+++ b/internal/query/validate.go
@@ -16,9 +16,10 @@ var keyPattern = regexp.MustCompile(`^[a-zA-Z0-9._\-/]+$`)
 // per-dataset whitelist; this is the coarse first line of defense.
 func (q *Query) Validate() error {
 	switch q.Dataset {
-	case DatasetSpans, DatasetLogs:
+	case DatasetSpans, DatasetLogs, DatasetMetrics:
 	default:
-		return fmt.Errorf("dataset must be %q or %q, got %q", DatasetSpans, DatasetLogs, q.Dataset)
+		return fmt.Errorf("dataset must be one of %q / %q / %q, got %q",
+			DatasetSpans, DatasetLogs, DatasetMetrics, q.Dataset)
 	}
 	if q.TimeRange.From.IsZero() || q.TimeRange.To.IsZero() {
 		return fmt.Errorf("time_range.from and time_range.to are required")

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -231,6 +231,28 @@ type FieldInfo struct {
 	Count     int64  `json:"count"`
 }
 
+// MetricSummary is a row in the metric-name picker.
+type MetricSummary struct {
+	Name        string `json:"name"`
+	Kind        string `json:"kind"`
+	Unit        string `json:"unit,omitempty"`
+	Description string `json:"description,omitempty"`
+	SeriesCount int64  `json:"series_count"`
+}
+
+// MetricSeriesSummary is one row in the series list for a given metric.
+type MetricSeriesSummary struct {
+	SeriesID       int64  `json:"series_id"`
+	ServiceName    string `json:"service_name"`
+	Name           string `json:"name"`
+	Kind           string `json:"kind"`
+	Unit           string `json:"unit,omitempty"`
+	Temporality    string `json:"temporality,omitempty"`
+	AttributesJSON string `json:"attributes"`
+	FirstSeenNS    int64  `json:"first_seen_ns"`
+	LastSeenNS     int64  `json:"last_seen_ns"`
+}
+
 // QueryColumn is the output of one select/group-by expression.
 type QueryColumn struct {
 	Name string `json:"name"`

--- a/internal/store/sqlite/queries.go
+++ b/internal/store/sqlite/queries.go
@@ -1266,6 +1266,81 @@ func coerceForJSON(v any) any {
 	}
 }
 
+// ListMetrics backs the /api/metrics name picker. One row per unique
+// (name, kind) tuple — two instruments sharing a name but different
+// kinds (rare but legal in OTLP) show up separately.
+func (s *Store) ListMetrics(ctx context.Context, f store.MetricFilter) ([]store.MetricSummary, error) {
+	limit := clampLimit(f.Limit, 200, 500)
+	var b strings.Builder
+	b.WriteString(`SELECT name, kind,
+		COALESCE(MAX(unit), '') AS unit,
+		COALESCE(MAX(description), '') AS description,
+		COUNT(*) AS series_count
+		FROM metric_series WHERE 1=1`)
+	args := []any{}
+	if f.Service != "" {
+		b.WriteString(" AND service_name = ?")
+		args = append(args, f.Service)
+	}
+	if f.Prefix != "" {
+		b.WriteString(" AND name LIKE ? || '%'")
+		args = append(args, f.Prefix)
+	}
+	b.WriteString(" GROUP BY name, kind ORDER BY name ASC LIMIT ?")
+	args = append(args, limit)
+	rows, err := s.reader.QueryContext(ctx, b.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.MetricSummary
+	for rows.Next() {
+		var m store.MetricSummary
+		if err := rows.Scan(&m.Name, &m.Kind, &m.Unit, &m.Description, &m.SeriesCount); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// ListMetricSeries returns the individual (attribute-set) series for a
+// metric name — the "one row per line on the chart" view.
+func (s *Store) ListMetricSeries(ctx context.Context, f store.MetricSeriesFilter) ([]store.MetricSeriesSummary, error) {
+	if f.Name == "" {
+		return nil, errors.New("metric name is required")
+	}
+	limit := clampLimit(f.Limit, 200, 1000)
+	var b strings.Builder
+	b.WriteString(`SELECT series_id, service_name, name, kind,
+		COALESCE(unit, ''), COALESCE(temporality, ''),
+		attributes, first_seen_ns, last_seen_ns
+		FROM metric_series WHERE name = ?`)
+	args := []any{f.Name}
+	if f.Service != "" {
+		b.WriteString(" AND service_name = ?")
+		args = append(args, f.Service)
+	}
+	b.WriteString(" ORDER BY last_seen_ns DESC LIMIT ?")
+	args = append(args, limit)
+	rows, err := s.reader.QueryContext(ctx, b.String(), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.MetricSeriesSummary
+	for rows.Next() {
+		var m store.MetricSeriesSummary
+		if err := rows.Scan(&m.SeriesID, &m.ServiceName, &m.Name, &m.Kind,
+			&m.Unit, &m.Temporality, &m.AttributesJSON,
+			&m.FirstSeenNS, &m.LastSeenNS); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) Retain(ctx context.Context, olderThanNS int64) error {
 	tx, err := s.writer.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -55,6 +55,9 @@ type Store interface {
 
 	SearchLogs(ctx context.Context, f LogFilter) ([]LogOut, string, error)
 
+	ListMetrics(ctx context.Context, f MetricFilter) ([]MetricSummary, error)
+	ListMetricSeries(ctx context.Context, f MetricSeriesFilter) ([]MetricSeriesSummary, error)
+
 	// RunQuery executes a pre-compiled structured query (SQL + args + column
 	// schema) against the read pool. All user-provided inputs have been
 	// whitelisted by the query package before we get here; sqlite parameter
@@ -66,4 +69,18 @@ type Store interface {
 	Clear(ctx context.Context) error
 
 	Close() error
+}
+
+// MetricFilter scopes /api/metrics — the metric-name picker.
+type MetricFilter struct {
+	Service string
+	Prefix  string
+	Limit   int
+}
+
+// MetricSeriesFilter scopes /api/metrics/{name}/series — series listing.
+type MetricSeriesFilter struct {
+	Name    string
+	Service string
+	Limit   int
 }


### PR DESCRIPTION
## Summary

Second stage (after #12). The storage + ingest from stage 1 now have query and listing surfaces so the UI (stage 3) can hook up.

## Query engine

- New \`DatasetMetrics = \"metrics\"\` alongside spans / logs. \`Validate\` accepts it.
- \`build()\` emits \`FROM metric_points p JOIN metric_series s ON s.series_id = p.series_id\` when dataset is metrics, via a new \`datasetFromClause()\` helper. Similarly \`datasetTimeColumn()\` returns \`p.time_ns\` and \`attributesColumn()\` returns \`s.attributes\` so json_extract fall-through targets the right column.
- \`realColumn\` grows a metrics branch: \`name\`, \`service.name\`, \`kind\`, \`unit\`, \`temporality\`, \`value\`, \`time_ns\`, \`start_time_ns\`, \`series_id\`.
- \`rawColumnsFor\` returns \`(time_ns, service_name, name, kind, value, attributes)\` so raw-rows mode on metrics yields one row per point with its catalog context.
- All existing span/log codepaths untouched — single-table unqualified references still work.

## New endpoints

- \`GET /api/metrics\` — \`{name, kind, unit, description, series_count}\` per unique \`(name, kind)\`. Filters: \`service\`, \`prefix\`, \`limit\`. Powers the metric picker.
- \`GET /api/metrics/{name}/series\` — lists series (attribute-set + facets) for one metric. Filters: \`service\`, \`limit\`. Powers the per-series view.

\`Store\` interface grows \`ListMetrics\` + \`ListMetricSeries\`. sqlite implementation follows the existing pattern of read-pool-only, clamped limits.

## Tests

Two new E2E tests (in \`internal/ingest/e2e_metrics_test.go\`):

- \`TestE2E_MetricsAPIListing\` — counter with 2 label-set series + an async gauge, asserts \`/api/metrics\` + \`/api/metrics/{name}/series\` return the right shape.
- \`TestE2E_MetricsQuery\` — issues a real \`POST /api/query\` with \`dataset: \"metrics\"\`, group-by a custom attribute, verifies MAX(value) totals match the cumulative sums. Also checks raw-rows mode returns the 6 expected columns.

## Verification

- [x] \`go test ./...\`
- [x] \`go vet ./...\`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)