### PR TITLE
feat(metrics): stage 3 — /metrics UI

### DIFF
--- a/ui/src/features/query/DefinePanel.tsx
+++ b/ui/src/features/query/DefinePanel.tsx
@@ -40,7 +40,7 @@ export function DefinePanel({ dataset, search, onChange, onRun, isRunning }: Pro
   );
   const service = typeof serviceFilter?.value === "string" ? serviceFilter.value : undefined;
 
-  const datasetLabel = dataset === "spans" ? "spans" : "logs";
+  const datasetLabel = dataset;
   const suggestionsForOrder = [
     ...selectOrDefault(search.select).map((a) =>
       a.op === "count" ? "count" : `${a.op}_${(a.field ?? "").replace(/[^a-zA-Z0-9_]/g, "_")}`,
@@ -104,7 +104,7 @@ export function DefinePanel({ dataset, search, onChange, onRun, isRunning }: Pro
             label="Select"
             description="What to compute. COUNT returns one number per result row; aggregations like P95, AVG, SUM, MIN/MAX, and COUNT_DISTINCT take a field and reduce its values. An empty Select returns raw events instead."
             isEmpty={false}
-            value={summarizeSelect(search.select)}
+            value={summarizeSelect(search.select, dataset)}
             editor={
               <SelectEditor
                 select={search.select}

--- a/ui/src/features/query/FilterChip.tsx
+++ b/ui/src/features/query/FilterChip.tsx
@@ -6,7 +6,7 @@ import { FilterInput } from "./FilterInput";
 
 interface Props {
   filter: Filter;
-  dataset?: "spans" | "logs";
+  dataset?: "spans" | "logs" | "metrics";
   service?: string;
   onChange: (f: Filter) => void;
   onRemove: () => void;

--- a/ui/src/features/query/FilterInput.tsx
+++ b/ui/src/features/query/FilterInput.tsx
@@ -58,7 +58,8 @@ export function FilterInput({
   }, []);
 
   const parsed = useMemo(() => parseFilter(text), [text]);
-  const signal = dataset === "spans" ? "span" : "log";
+  const signal =
+    dataset === "spans" ? "span" : dataset === "logs" ? "log" : "metric";
 
   // Debounce only the prefix. The field/phase flip immediately so the
   // dropdown contents switch at once; only the prefix-filtered fetch
@@ -253,6 +254,14 @@ const SYNTHETIC_FIELDS_BY_DATASET: Record<Dataset, { key: string; type: string }
     { key: "severity_number", type: "int" },
     { key: "error", type: "bool" },
     { key: "trace_id", type: "string" },
+    { key: "time_ns", type: "time" },
+  ],
+  metrics: [
+    { key: "name", type: "string" },
+    { key: "kind", type: "string" },
+    { key: "unit", type: "string" },
+    { key: "temporality", type: "string" },
+    { key: "value", type: "float" },
     { key: "time_ns", type: "time" },
   ],
 };

--- a/ui/src/features/query/MetricPicker.tsx
+++ b/ui/src/features/query/MetricPicker.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, Check } from "lucide-react";
+import { Popover } from "../../components/ui/Popover";
+import { api, type MetricSummary } from "../../lib/api";
+
+interface Props {
+  /** The currently-picked metric name, or empty when none is selected. */
+  value: string;
+  /** Fires when the user picks a metric. */
+  onChange: (metric: MetricSummary | null) => void;
+  /** Scope the /api/metrics listing to one service (optional). */
+  service?: string;
+}
+
+/**
+ * Popover combobox for picking a metric by name. The server returns
+ * one row per unique (name, kind) tuple so we display both — rare but
+ * legal to have the same name with different kinds, and the UI must
+ * disambiguate.
+ */
+export function MetricPicker({ value, onChange, service }: Props) {
+  const [q, setQ] = useState("");
+  const metrics = useQuery({
+    queryKey: ["metrics.list", service, q],
+    queryFn: ({ signal }) => {
+      const p = new URLSearchParams();
+      if (service) p.set("service", service);
+      if (q) p.set("prefix", q);
+      p.set("limit", "100");
+      return api.listMetrics(p, signal);
+    },
+    staleTime: 10_000,
+  });
+  const items: MetricSummary[] = metrics.data?.metrics ?? [];
+
+  return (
+    <Popover
+      align="start"
+      trigger={
+        <button
+          type="button"
+          className="flex items-center gap-2 px-3 py-1.5 rounded-md border text-sm hover:bg-[var(--color-card-hover)]"
+          style={{
+            background: "var(--color-surface)",
+            borderColor: "var(--color-border)",
+          }}
+        >
+          <span className="font-mono">
+            {value || <span style={{ color: "var(--color-ink-muted)" }}>Pick metric…</span>}
+          </span>
+          <ChevronDown className="w-4 h-4" />
+        </button>
+      }
+    >
+      <div className="flex flex-col gap-2" style={{ minWidth: 320 }}>
+        <input
+          autoFocus
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Filter metric names…"
+          className="px-2 py-1 rounded border font-mono text-sm"
+          style={{ borderColor: "var(--color-border)" }}
+        />
+        <div className="max-h-80 overflow-auto">
+          {metrics.isLoading && (
+            <div
+              className="px-2 py-1 text-sm"
+              style={{ color: "var(--color-ink-muted)" }}
+            >
+              Loading…
+            </div>
+          )}
+          {!metrics.isLoading && items.length === 0 && (
+            <div
+              className="px-2 py-1 text-sm"
+              style={{ color: "var(--color-ink-muted)" }}
+            >
+              No metrics {q ? `matching "${q}"` : "ingested yet"}.
+            </div>
+          )}
+          {items.map((m) => {
+            const active = m.name === value;
+            return (
+              <button
+                key={`${m.name}-${m.kind}`}
+                type="button"
+                onClick={() => onChange(active ? null : m)}
+                className="flex items-center gap-2 w-full px-2 py-1.5 text-left text-sm rounded hover:bg-[var(--color-card-hover)]"
+                style={active ? { background: "var(--color-card-stripe)" } : undefined}
+              >
+                <Check
+                  className="w-3.5 h-3.5 shrink-0"
+                  style={{ opacity: active ? 1 : 0 }}
+                />
+                <span className="flex-1 min-w-0">
+                  <span className="font-mono truncate block">{m.name}</span>
+                  {m.description ? (
+                    <span
+                      className="text-xs truncate block"
+                      style={{ color: "var(--color-ink-muted)" }}
+                    >
+                      {m.description}
+                    </span>
+                  ) : null}
+                </span>
+                <span
+                  className="text-[10px] uppercase px-1 rounded shrink-0"
+                  style={{
+                    background: "var(--color-card-stripe)",
+                    color: "var(--color-ink-muted)",
+                  }}
+                >
+                  {m.kind}
+                </span>
+                {m.unit ? (
+                  <span
+                    className="text-[10px] font-mono shrink-0"
+                    style={{ color: "var(--color-ink-muted)" }}
+                  >
+                    {m.unit}
+                  </span>
+                ) : null}
+                <span
+                  className="text-xs shrink-0"
+                  style={{ color: "var(--color-ink-muted)" }}
+                >
+                  {m.series_count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </Popover>
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -73,6 +73,26 @@ export interface LogOut {
   attributes: string;
 }
 
+export interface MetricSummary {
+  name: string;
+  kind: string;
+  unit?: string;
+  description?: string;
+  series_count: number;
+}
+
+export interface MetricSeriesSummary {
+  series_id: number;
+  service_name: string;
+  name: string;
+  kind: string;
+  unit?: string;
+  temporality?: string;
+  attributes: string;
+  first_seen_ns: number;
+  last_seen_ns: number;
+}
+
 /**
  * HttpError carries the status code alongside the parsed body so callers
  * can switch on 404/400 without string-matching the message.
@@ -125,6 +145,18 @@ export const api = {
   searchLogs: (params: URLSearchParams, signal?: AbortSignal) =>
     getJSON<{ logs: LogOut[]; next_cursor: string }>(
       `/api/logs/search?${params.toString()}`,
+      signal,
+    ),
+
+  listMetrics: (params: URLSearchParams, signal?: AbortSignal) =>
+    getJSON<{ metrics: MetricSummary[] }>(
+      `/api/metrics?${params.toString()}`,
+      signal,
+    ),
+
+  listMetricSeries: (name: string, params: URLSearchParams, signal?: AbortSignal) =>
+    getJSON<{ series: MetricSeriesSummary[] }>(
+      `/api/metrics/${encodeURIComponent(name)}/series?${params.toString()}`,
       signal,
     ),
 };

--- a/ui/src/lib/query.ts
+++ b/ui/src/lib/query.ts
@@ -5,7 +5,7 @@
  */
 import { z } from "zod";
 
-export const DATASETS = ["spans", "logs"] as const;
+export const DATASETS = ["spans", "logs", "metrics"] as const;
 export type Dataset = (typeof DATASETS)[number];
 
 export const AGG_OPS = [
@@ -398,11 +398,18 @@ export const querySearchSchema = z.object({
 export type QuerySearch = z.infer<typeof querySearchSchema>;
 
 /**
- * Normalize an empty SELECT to the default COUNT so downstream code can
- * always assume ≥1 aggregation.
+ * Normalize an empty SELECT to a sensible default. Spans and logs default
+ * to COUNT (number of events per bucket). Metrics default to MAX(value) —
+ * counts of metric points are meaningless; MAX captures the cumulative
+ * level of a counter and the sampled value of a gauge alike.
  */
-export function selectOrDefault(sel: Aggregation[]): Aggregation[] {
-  return sel.length === 0 ? [{ op: "count" }] : sel;
+export function selectOrDefault(
+  sel: Aggregation[],
+  dataset?: Dataset,
+): Aggregation[] {
+  if (sel.length > 0) return sel;
+  if (dataset === "metrics") return [{ op: "max", field: "value" }];
+  return [{ op: "count" }];
 }
 
 // ---------------------------------------------------------------------------
@@ -441,7 +448,7 @@ export function buildCountQuery(
       from: new Date(resolved.fromMs).toISOString(),
       to: new Date(resolved.toMs).toISOString(),
     },
-    select: selectOrDefault(search.select),
+    select: selectOrDefault(search.select, dataset),
     where: search.where,
     group_by: search.group_by,
     order_by: search.order_by,
@@ -468,7 +475,7 @@ export function buildOverviewQuery(
       from: new Date(resolved.fromMs).toISOString(),
       to: new Date(resolved.toMs).toISOString(),
     },
-    select: selectOrDefault(search.select),
+    select: selectOrDefault(search.select, dataset),
     where: search.where,
     group_by: search.group_by,
     order_by: search.order_by,
@@ -478,8 +485,11 @@ export function buildOverviewQuery(
 }
 
 /** Short human summary of the SELECT list for the Define panel. */
-export function summarizeSelect(sel: Aggregation[]): string {
-  const items = selectOrDefault(sel);
+export function summarizeSelect(
+  sel: Aggregation[],
+  dataset?: Dataset,
+): string {
+  const items = selectOrDefault(sel, dataset);
   return items
     .map((a) => {
       if (a.op === "count") return "COUNT";

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -7,6 +7,7 @@ import {
 import { RootLayout } from "./routes/root";
 import { TracesPage } from "./routes/TracesPage";
 import { LogsPage } from "./routes/LogsPage";
+import { MetricsPage } from "./routes/MetricsPage";
 import { TraceView } from "./features/traces/TraceView";
 import { querySearchSchema } from "./lib/query";
 
@@ -47,11 +48,22 @@ export const logsRoute = createRoute({
   component: LogsPage,
 });
 
+// /metrics — metric-name picker up top; same Define/Chart/Explore
+// skeleton as the other datasets, query engine running against the
+// metric_points + metric_series join.
+export const metricsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/metrics",
+  validateSearch: querySearchSchema,
+  component: MetricsPage,
+});
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
   tracesRoute,
   traceDetailRoute,
   logsRoute,
+  metricsRoute,
 ]);
 
 export const router = createRouter({

--- a/ui/src/routes/MetricsPage.tsx
+++ b/ui/src/routes/MetricsPage.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useRef, useState, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Accordion } from "../components/ui/Accordion";
+import { DefinePanel } from "../features/query/DefinePanel";
+import { QueryChart } from "../features/query/QueryChart";
+import { ResultTabs } from "../features/query/ResultTabs";
+import { MetricPicker } from "../features/query/MetricPicker";
+import {
+  bucketMsFor,
+  buildCountQuery,
+  refreshIntervalMs,
+  resolveSearchRange,
+  runQuery,
+  type QuerySearch,
+} from "../lib/query";
+import { useRefreshPersistence } from "../lib/refreshPersistence";
+import { metricsRoute } from "../router";
+
+const COLLAPSE_DISTANCE = 220;
+
+/**
+ * Metrics explorer. Top-of-page picker selects a metric by name; the
+ * name+kind land as a WHERE filter pinned to the rest of the query, so
+ * the chart and tables only show that metric's data. Everything below
+ * (DefinePanel, accordions, tabs) reuses the shared components the
+ * traces/logs pages use — metrics is just another `dataset` to the
+ * query engine.
+ */
+export function MetricsPage() {
+  const search = metricsRoute.useSearch();
+  const navigate = useNavigate();
+  const [queryOpen, setQueryOpen] = useState(true);
+  const [chartOpen, setChartOpen] = useState(true);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    setQueryOpen(true);
+    setChartOpen(true);
+    setScrollProgress(0);
+  }, [search.tab]);
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
+
+  const handleExploreScrollY = (y: number) => {
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const p = Math.max(0, Math.min(1, y / COLLAPSE_DISTANCE));
+      setScrollProgress((prev) => (prev === p ? prev : p));
+    });
+  };
+  const reopen = (set: (v: boolean) => void) => {
+    setScrollProgress(0);
+    set(true);
+  };
+
+  const setSearch = (next: QuerySearch) =>
+    navigate({ to: "/metrics", search: next as unknown as Record<string, unknown> });
+
+  useRefreshPersistence(search, setSearch);
+
+  // The picker drives the query by pinning a `name = <metric>` WHERE
+  // filter. Whatever filters the user has set in the Define panel stay
+  // orthogonal to the picker.
+  const pickedName = useMemo(() => {
+    const nameFilter = search.where.find(
+      (f) => f.field === "name" && f.op === "=",
+    );
+    return typeof nameFilter?.value === "string" ? nameFilter.value : "";
+  }, [search.where]);
+
+  const chart = useQuery({
+    // Gate the chart on having picked a metric. Metrics datasets without
+    // a name filter would try to aggregate across every series in the
+    // store — usually not what the user wants.
+    queryKey: ["query", "metrics", search],
+    queryFn: ({ signal }) =>
+      runQuery(buildCountQuery("metrics", search), signal),
+    refetchInterval: refreshIntervalMs(search.refresh),
+    enabled: pickedName !== "",
+  });
+
+  const resolved = resolveSearchRange(search);
+  const handleBucketClick = (tMs: number) => {
+    const bucketMs = bucketMsFor(resolved.durationMs, search.granularity);
+    setSearch({
+      ...search,
+      from: tMs,
+      to: tMs + bucketMs,
+      granularity: "auto",
+      tab: "explore",
+    });
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      <Accordion
+        label="Query"
+        open={queryOpen}
+        collapseProgress={scrollProgress}
+        onToggle={() => (queryOpen ? setQueryOpen(false) : reopen(setQueryOpen))}
+        collapsedSummary={querySummary(search, pickedName)}
+      >
+        <div
+          className="flex items-center gap-3 px-4 pt-3"
+          style={{ color: "var(--color-ink-muted)" }}
+        >
+          <span className="text-sm">Metric</span>
+          <MetricPicker
+            value={pickedName}
+            onChange={(m) => {
+              const rest = search.where.filter(
+                (f) => !(f.field === "name" && f.op === "="),
+              );
+              if (m) {
+                setSearch({
+                  ...search,
+                  where: [...rest, { field: "name", op: "=", value: m.name }],
+                });
+              } else {
+                setSearch({ ...search, where: rest });
+              }
+            }}
+          />
+        </div>
+        <DefinePanel
+          dataset="metrics"
+          search={search}
+          onChange={setSearch}
+          onRun={() => chart.refetch()}
+          isRunning={chart.isFetching}
+        />
+      </Accordion>
+      <Accordion
+        label="Chart"
+        open={chartOpen}
+        onToggle={() => setChartOpen((o) => !o)}
+      >
+        <div className="p-3" style={{ background: "var(--color-surface)" }}>
+          {pickedName === "" ? (
+            <div
+              className="flex items-center justify-center text-sm"
+              style={{ color: "var(--color-ink-muted)", height: 125 }}
+            >
+              Pick a metric above to chart it.
+            </div>
+          ) : (
+            <QueryChart
+              result={chart.data}
+              loading={chart.isPending}
+              error={chart.error}
+              bucketMs={bucketMsFor(resolved.durationMs, search.granularity)}
+              fromMs={resolved.fromMs}
+              toMs={resolved.toMs}
+              onBucketClick={handleBucketClick}
+            />
+          )}
+        </div>
+      </Accordion>
+      <div className="flex-1 overflow-hidden">
+        <ResultTabs
+          dataset="metrics"
+          search={search}
+          onTabChange={(tab) => setSearch({ ...search, tab })}
+          onExploreScrollY={handleExploreScrollY}
+        />
+      </div>
+    </div>
+  );
+}
+
+function querySummary(search: QuerySearch, picked: string): string {
+  const parts: string[] = [];
+  if (picked) parts.push(picked);
+  const otherFilters = search.where.filter(
+    (f) => !(f.field === "name" && f.op === "="),
+  );
+  if (otherFilters.length)
+    parts.push(
+      `${otherFilters.length} filter${otherFilters.length === 1 ? "" : "s"}`,
+    );
+  if (search.group_by.length)
+    parts.push(`group by ${search.group_by.join(", ")}`);
+  return parts.join(" · ");
+}

--- a/ui/src/routes/root.tsx
+++ b/ui/src/routes/root.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
 import { Link, Outlet, useLocation } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { Activity, ScrollText, PanelLeftClose, PanelLeft } from "lucide-react";
+import {
+  Activity,
+  Gauge,
+  ScrollText,
+  PanelLeftClose,
+  PanelLeft,
+} from "lucide-react";
 import clsx from "clsx";
 
 const STORAGE_KEY = "waggle.sidebar.collapsed";
@@ -106,6 +112,7 @@ export function RootLayout() {
         <nav className="p-2 flex flex-col gap-1 flex-1">
           {navItem("/traces", "Traces", <Activity />, pathname.startsWith("/traces"))}
           {navItem("/logs", "Logs", <ScrollText />, pathname.startsWith("/logs"))}
+          {navItem("/metrics", "Metrics", <Gauge />, pathname.startsWith("/metrics"))}
         </nav>
         <div
           className={clsx(


### PR DESCRIPTION
## Summary

Third and final stage for scalar metrics. Ships \`/metrics\` — a third sidebar entry after Traces and Logs. Reuses the Query / Chart / Explore skeleton by treating metrics as another dataset.

## New components

- **MetricPicker** — popover combobox hitting \`/api/metrics\`. Displays \`name\` + description + kind badge + unit + series count per row. Picking a metric pins a \`where: [{field: \"name\", op: \"=\", value: <metric>}]\` filter onto the page search.
- **MetricsPage** — mirrors \`TracesPage\` + \`LogsPage\`. MetricPicker sits above the DefinePanel; everything else (Accordion, QueryChart, ResultTabs, refresh persistence, scroll-collapse) is the shared chrome. Chart is gated on \"metric picked\" so the page doesn't aggregate across every metric in the store by default.

## Shared plumbing

- \`DATASETS\` grows \`\"metrics\"\`.
- \`selectOrDefault\` takes an optional dataset — metrics defaults to \`MAX(value)\` (cumulative counter level or sampled gauge value; counts of points are meaningless).
- \`summarizeSelect\` threads dataset so the Define panel shows the right default.
- \`lib/api.ts\`: \`listMetrics\` + \`listMetricSeries\` clients + \`MetricSummary\` / \`MetricSeriesSummary\` types.
- \`FilterInput\`: dataset→signal map handles metrics for \`/api/fields\` lookups. \`SYNTHETIC_FIELDS_BY_DATASET\` gains a metrics entry (name / kind / unit / temporality / value / time_ns).
- DefinePanel's dataset pill shows the actual dataset (was hardcoded spans/logs).

## Verification

- [x] \`npx tsc --noEmit -p tsconfig.app.json\`
- [x] \`go test ./...\` (no backend changes in this PR; existing tests still green)
- [x] Loaded \`/metrics\` in dev, confirmed the empty state renders and the DefinePanel reflects the right dataset + aggregation default.
- [ ] CI

## Known follow-up (intentional)

\`cmd/loadgen\` doesn't emit metrics yet, so the picker will be empty against a fresh waggle. A demo counter + gauge per service would give the UI something to render out of the box — small next-step PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)