### PR TITLE
Whisker-style skew indicators + 35ms demo skew on checkout trace

### DIFF
--- a/cmd/loadgen/templates.go
+++ b/cmd/loadgen/templates.go
@@ -655,8 +655,18 @@ func emitBigCheckoutFlow(ctx context.Context, tracers Tracers, loggers Loggers) 
 	notif := tracers["notifications"]
 	db := tracers["db-worker"]
 
+	// Deliberate clock-skew injection: the api-gateway's clock runs 35ms
+	// behind everyone else, so the root span's reported [start, end]
+	// sits entirely 35ms in the past relative to its children. Same
+	// reported duration as before — just shifted. Children keep their
+	// real wall-clock timestamps, so they all appear to start a bit
+	// before root's reported start *and* the last child's actual end
+	// overshoots root's reported end by ~35ms, exercising the
+	// extendedToNS propagation and the right-hand whisker.
+	const skewOffset = 35 * time.Millisecond
 	ctx, root := api.Start(ctx, "POST /checkout/complete",
-		trace.WithSpanKind(trace.SpanKindServer))
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithTimestamp(time.Now().Add(-skewOffset)))
 	root.SetAttributes(
 		attribute.String("http.request.method", "POST"),
 		attribute.String("http.route", "/checkout/complete"),
@@ -667,7 +677,9 @@ func emitBigCheckoutFlow(ctx context.Context, tracers Tracers, loggers Loggers) 
 		attribute.Int("cart.item_count", 3+rand.IntN(8)),
 		attribute.String("checkout.flow", "one_click"),
 	)
-	defer root.End()
+	defer func() {
+		root.End(trace.WithTimestamp(time.Now().Add(-skewOffset)))
+	}()
 
 	// simpleChild starts a sibling under ctx, sets a few attributes, and
 	// sleeps a short realistic duration before ending. Keeps the body below

--- a/ui/src/features/traces/Waterfall.tsx
+++ b/ui/src/features/traces/Waterfall.tsx
@@ -450,10 +450,10 @@ function Row({
 
 /**
  * Whisker indicating clock skew on one side of the bar: a thin horizontal
- * wire just below the bar, a short drop connecting it to the bar's own
- * edge, and a vertical cap at the extreme descendant bound. Drawn with the
- * service colour at reduced opacity so it reads as "related to the bar
- * but not part of its reported duration".
+ * wire emerging from the bar's midline out to the extreme descendant
+ * bound, terminated by a vertical cap. Drawn with the service colour at
+ * reduced opacity so it reads as "related to the bar but not part of its
+ * reported duration".
  */
 function SkewWhisker({
   color,
@@ -468,15 +468,13 @@ function SkewWhisker({
   /** Right edge of the horizontal wire, as % of the timeline. */
   wireToPct: number;
 }) {
-  // Bar is drawn at top:8 height:10 (so bottom edge y=18). The wire sits
-  // 3px below with a 1px stroke, caps are 7px tall straddling the wire.
-  const wireTop = 21;
-  const capTop = 18;
+  // Bar is drawn at top:8 height:10 (midline y=13). Centre the wire and
+  // cap on that midline so the whisker reads as continuing straight out
+  // of the bar rather than branching below it.
+  const wireTop = 13;
+  const capTop = 10;
   const capHeight = 7;
-  const dropTop = 18;
-  const dropHeight = 4;
   const capPct = side === "left" ? wireFromPct : wireToPct;
-  const dropPct = side === "left" ? wireToPct : wireFromPct;
   const wireWidthPct = Math.max(wireToPct - wireFromPct, 0);
   return (
     <>
@@ -501,18 +499,6 @@ function SkewWhisker({
           background: color,
           opacity: 0.7,
           transform: "translateX(-50%)",
-        }}
-      />
-      <div
-        className="absolute"
-        style={{
-          left: `${dropPct}%`,
-          top: dropTop,
-          height: dropHeight,
-          width: 1,
-          background: color,
-          opacity: 0.5,
-          transform: side === "right" ? "translateX(-100%)" : undefined,
         }}
       />
     </>

--- a/ui/src/features/traces/Waterfall.tsx
+++ b/ui/src/features/traces/Waterfall.tsx
@@ -373,17 +373,25 @@ function Row({
             means percentages land inside the padded area instead of
             spilling to the timeline column's border edges. */}
         <div className="relative w-full h-full">
-        {/* Dashed skew extension — drawn under the solid bar. */}
-        {row.hasSkew && (
-          <div
-            className="absolute border-t border-dashed"
-            style={{
-              left: `${extFromPct}%`,
-              width: `${Math.max(extToPct - extFromPct, 0.2)}%`,
-              top: "50%",
-              borderColor: color,
-              opacity: 0.5,
-            }}
+        {/* Skew whiskers — rendered as a thin wire just below the bar
+            with a vertical cap at the extreme descendant bound, and a
+            short drop from the bar's own edge down to the wire. Only the
+            side(s) with actual overrun draw. Mirrors Honeycomb's box-plot
+            convention for "span covered more time than it claimed". */}
+        {row.extendedFromNS < row.span.start_ns && (
+          <SkewWhisker
+            color={color}
+            side="left"
+            wireFromPct={extFromPct}
+            wireToPct={leftPct}
+          />
+        )}
+        {row.extendedToNS > row.span.end_ns && (
+          <SkewWhisker
+            color={color}
+            side="right"
+            wireFromPct={leftPct + widthPct}
+            wireToPct={extToPct}
           />
         )}
         {/* Solid own-duration bar. Errors flip to red outright for
@@ -437,6 +445,77 @@ function Row({
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * Whisker indicating clock skew on one side of the bar: a thin horizontal
+ * wire just below the bar, a short drop connecting it to the bar's own
+ * edge, and a vertical cap at the extreme descendant bound. Drawn with the
+ * service colour at reduced opacity so it reads as "related to the bar
+ * but not part of its reported duration".
+ */
+function SkewWhisker({
+  color,
+  side,
+  wireFromPct,
+  wireToPct,
+}: {
+  color: string;
+  side: "left" | "right";
+  /** Left edge of the horizontal wire, as % of the timeline. */
+  wireFromPct: number;
+  /** Right edge of the horizontal wire, as % of the timeline. */
+  wireToPct: number;
+}) {
+  // Bar is drawn at top:8 height:10 (so bottom edge y=18). The wire sits
+  // 3px below with a 1px stroke, caps are 7px tall straddling the wire.
+  const wireTop = 21;
+  const capTop = 18;
+  const capHeight = 7;
+  const dropTop = 18;
+  const dropHeight = 4;
+  const capPct = side === "left" ? wireFromPct : wireToPct;
+  const dropPct = side === "left" ? wireToPct : wireFromPct;
+  const wireWidthPct = Math.max(wireToPct - wireFromPct, 0);
+  return (
+    <>
+      <div
+        className="absolute"
+        style={{
+          left: `${wireFromPct}%`,
+          width: `${wireWidthPct}%`,
+          top: wireTop,
+          height: 1,
+          background: color,
+          opacity: 0.7,
+        }}
+      />
+      <div
+        className="absolute"
+        style={{
+          left: `${capPct}%`,
+          top: capTop,
+          height: capHeight,
+          width: 1,
+          background: color,
+          opacity: 0.7,
+          transform: "translateX(-50%)",
+        }}
+      />
+      <div
+        className="absolute"
+        style={{
+          left: `${dropPct}%`,
+          top: dropTop,
+          height: dropHeight,
+          width: 1,
+          background: color,
+          opacity: 0.5,
+          transform: side === "right" ? "translateX(-100%)" : undefined,
+        }}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Replace the mid-bar dashed skew line with a per-side **whisker**: thin horizontal wire below the bar, short drop connecting the bar edge to the wire, vertical cap at the far end. Rendered only on the side(s) that actually overrun, so spans without skew stay clean.
- Shift the demo `POST /checkout/complete` root span 35ms earlier than the rest of the trace (api-gateway's clock runs behind). Children keep their real wall-clock timestamps, so the last child's actual end now overshoots root's reported end — exercising the whisker UI with a visible case on the canned demo trace.

## Test plan
- [x] `go build ./...` clean
- [x] `ui/ npx tsc -b` clean
- [ ] Run loadgen, open a freshly-emitted `POST /checkout/complete` trace, confirm the root bar has a right-side whisker extending ~35ms past its reported end, with a visible cap at the extreme
- [ ] Confirm spans without skew show no whisker — only the filled bar
- [ ] Warning-triangle icon still appears next to root's span name (kept as the semantic/a11y indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)