### PR TITLE
Drop broken cross-signal "events" dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Local OpenTelemetry viewer inspired by Honeycomb — named for the
   field, so `MAX(requests.total)` resolves with plain SQL). WAL mode, FTS5
   for log/span-name search.
 - **Four peer surfaces:** `/traces`, `/logs`, `/metrics`, and `/events`
-  (cross-signal) — each driven by the same Honeycomb-style query builder.
+  (the general explore page) — each driven by the same Honeycomb-style
+  query builder.
 - **Per-chart controls.** Multi-`SELECT` queries render one chart per
   aggregation, each with its own Edit-chart popover (missing-values
   handling) and SI-suffixed y-axis.
@@ -34,7 +35,7 @@ The `/traces` Explore-Data tab — root spans for the last hour, filtered
 to `is_root = true`. Each row carries a SIGNAL pill, service name,
 operation name, duration, status, and a trace-id link that opens the
 waterfall. The dataset pill at the top-left switches between
-`spans`, `logs`, `metrics`, and the cross-signal `events` view.
+`spans`, `logs`, and `metrics`.
 
 ![Spans Explore Data, filtered to root spans](docs/traces-list.png)
 
@@ -101,8 +102,8 @@ Four peer routes, all driven by the same query builder:
   field: type `MAX(requests.total)` or `P99(memory.used_bytes)` in the
   Select cell. Field autocomplete pulls metric names from the attribute
   catalog.
-- `/events` — cross-signal view. Runs with no signal-type prefix, so
-  one query can slice across spans, logs, and metrics.
+- `/events` — the general explore page. Pick a dataset (spans, logs,
+  or metrics) and drive any structured query from a single surface.
 
 Every URL serialises the full query state (filters, group-by, aggregates,
 time range, granularity) so shared links reproduce the view.

--- a/internal/query/builder.go
+++ b/internal/query/builder.go
@@ -99,43 +99,6 @@ func (b *builder) buildRaw() (Compiled, error) {
 // positional output into typed rows.
 func rawColumnsFor(d Dataset) ([]Column, []string) {
 	switch d {
-	case DatasetEvents:
-		// Mixed-signal view. Every row carries signal_type; per-signal
-		// fields are NULL when they don't apply. The UI renders each row
-		// polymorphically based on signal_type.
-		cols := []Column{
-			{Name: "time_ns", Type: "time"},
-			{Name: "signal_type", Type: "string"},
-			{Name: "service_name", Type: "string"},
-			{Name: "name", Type: "string"},
-			{Name: "trace_id", Type: "string"},
-			{Name: "span_id", Type: "string"},
-			{Name: "duration_ns", Type: "int"},
-			{Name: "status_code", Type: "int"},
-			{Name: "severity_number", Type: "int"},
-			{Name: "severity_text", Type: "string"},
-			{Name: "body", Type: "string"},
-			{Name: "metric_kind", Type: "string"},
-			{Name: "value", Type: "float"},
-			{Name: "attributes", Type: "string"},
-		}
-		exprs := []string{
-			"time_ns",
-			"signal_type",
-			"service_name",
-			"name",
-			"hex(trace_id)",
-			"hex(span_id)",
-			"duration_ns",
-			"status_code",
-			"severity_number",
-			"severity_text",
-			"body",
-			"metric_kind",
-			"value",
-			"attributes",
-		}
-		return cols, exprs
 	case DatasetMetrics:
 		// Metrics are folded wide-events: one row per unique (time, label
 		// set) with metric names as attribute keys. No dedicated name /

--- a/internal/query/types.go
+++ b/internal/query/types.go
@@ -12,16 +12,17 @@ import (
 	"time"
 )
 
-// Dataset selects a preset filter on the unified events table. "spans",
-// "logs", "metrics" pin the query to one signal via a signal_type='…'
-// prefix; "events" runs across every signal with no prefix.
+// Dataset pins a query to exactly one signal type: spans/logs query the
+// shared events table with a signal_type predicate; metrics query the
+// metric_events table. Cross-signal queries are not supported — each
+// table has its own column set, so a mixed-signal SELECT can't be
+// expressed without a UNION that doesn't pay for its complexity.
 type Dataset string
 
 const (
 	DatasetSpans   Dataset = "spans"
 	DatasetLogs    Dataset = "logs"
 	DatasetMetrics Dataset = "metrics"
-	DatasetEvents  Dataset = "events"
 )
 
 // Query is the wire-level structured query.

--- a/internal/query/validate.go
+++ b/internal/query/validate.go
@@ -16,10 +16,10 @@ var keyPattern = regexp.MustCompile(`^[a-zA-Z0-9._\-/]+$`)
 // per-dataset whitelist; this is the coarse first line of defense.
 func (q *Query) Validate() error {
 	switch q.Dataset {
-	case DatasetSpans, DatasetLogs, DatasetMetrics, DatasetEvents:
+	case DatasetSpans, DatasetLogs, DatasetMetrics:
 	default:
-		return fmt.Errorf("dataset must be one of %q / %q / %q / %q, got %q",
-			DatasetSpans, DatasetLogs, DatasetMetrics, DatasetEvents, q.Dataset)
+		return fmt.Errorf("dataset must be one of %q / %q / %q, got %q",
+			DatasetSpans, DatasetLogs, DatasetMetrics, q.Dataset)
 	}
 	if q.TimeRange.From.IsZero() || q.TimeRange.To.IsZero() {
 		return fmt.Errorf("time_range.from and time_range.to are required")

--- a/ui/src/features/query/EventsTable.tsx
+++ b/ui/src/features/query/EventsTable.tsx
@@ -23,13 +23,9 @@ interface Props {
 
 /**
  * Events table. Sits below the chart and shows matching rows for the current
- * dataset + WHERE + time range. Rows render polymorphically based on each
- * row's `signal_type`: span rows show duration + status + trace link; log
- * rows show severity + body; metric rows show metric kind + value.
- *
- * When the current dataset is "events" (all signals) rows from different
- * signals mix naturally. When it's pinned to spans/logs/metrics the render
- * path is the same — every row simply carries the same signal_type.
+ * dataset + WHERE + time range. Rows render based on the dataset's row
+ * shape — span rows show duration + status + trace link; log rows show
+ * severity + body; metric rows show the folded attributes JSON.
  */
 export function EventsTable({ dataset, search, onScrollY }: Props) {
   const result = useQuery({

--- a/ui/src/features/query/FilterInput.tsx
+++ b/ui/src/features/query/FilterInput.tsx
@@ -240,13 +240,6 @@ interface Suggestion {
 // them first in autocomplete gives users a fast path to the common ones
 // without having to know the attribute-key catalog.
 const SYNTHETIC_FIELDS_BY_DATASET: Record<Dataset, { key: string; type: string }[]> = {
-  events: [
-    { key: "signal_type", type: "string" },
-    { key: "service.name", type: "string" },
-    { key: "name", type: "string" },
-    { key: "trace_id", type: "string" },
-    { key: "time_ns", type: "time" },
-  ],
   spans: [
     { key: "is_root", type: "bool" },
     { key: "error", type: "bool" },

--- a/ui/src/lib/query.ts
+++ b/ui/src/lib/query.ts
@@ -5,16 +5,14 @@
  */
 import { z } from "zod";
 
-// "events" is the mixed-signal view (no signal_type prefix filter). The
-// other three pin queries to one signal. The UI defaults to "events" and
-// lets the user narrow via a pill in the Define panel.
-export const DATASETS = ["events", "spans", "logs", "metrics"] as const;
+// Each dataset pins queries to one signal: spans/logs share the events
+// table (signal_type predicate); metrics hit metric_events. The UI
+// defaults to "spans" — the waterfall landing page.
+export const DATASETS = ["spans", "logs", "metrics"] as const;
 export type Dataset = (typeof DATASETS)[number];
 
 export function datasetLabel(d: Dataset): string {
   switch (d) {
-    case "events":
-      return "events";
     case "spans":
       return "spans";
     case "logs":
@@ -383,7 +381,7 @@ const orderSchema = z.object({
 });
 
 export const querySearchSchema = z.object({
-  dataset: z.enum(DATASETS).default("events"),
+  dataset: z.enum(DATASETS).default("spans"),
   range: z.enum(TIME_RANGES).default("1h"),
   // Absolute start/end in milliseconds. When both are set, they override
   // `range` — this is what click-to-zoom and the custom picker write. The


### PR DESCRIPTION
## Summary
The `events` dataset's raw-rows mode still emitted `SELECT metric_kind, value` against the shared `events` table — but metrics live in `metric_events` now, and those columns don't exist there. Result was a 500 from SQLite (`no such column: metric_kind`) whenever anyone ran a raw-rows query with dataset=`events`. Reproduced via the UI.

Rather than build a `UNION ALL` across two differently-shaped tables to resurrect cross-signal rows, remove the dataset. `/traces`, `/logs`, `/metrics` already cover the individual signal views, and trace_id correlation still works across them.

## Changes
- **Backend** (`internal/query`): drop `DatasetEvents` constant, its validator case, and the broken `rawColumnsFor` branch.
- **UI** (`ui/src/lib/query.ts`): remove `"events"` from `DATASETS`, flip the default dataset from `events` → `spans`.
- **UI** (`FilterInput.tsx`): remove the `events` entry from the per-dataset synthetic-fields record so `Record<Dataset, …>` stays exhaustive under the new type.
- **Comments/docs**: stale cross-signal wording scrubbed from README + EventsTable header.

The `/events` URL path stays — it's still the general explore page, just with a dataset pill that offers three choices instead of four.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` clean across api, ingest, query, sqlite
- [x] `ui/ npx tsc -b` clean
- [ ] Existing URL with `?dataset=events` should fall back to the `spans` default via Zod's `z.enum(...).default(...)` — verify in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)