### PR TITLE
Query history: /history route with dedup'd recent queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ Four peer routes, all driven by the same query builder:
   catalog.
 - `/events` — the general explore page. Pick a dataset (spans, logs,
   or metrics) and drive any structured query from a single surface.
+- `/history` — recent queries, deduplicated. Every successful `/events`
+  query lands in a local `query_history` table keyed by a hash of the
+  AST (time range excluded), so repeats bump a run counter rather than
+  pile up new rows. Clicking an entry rehydrates the URL and re-runs
+  the query against its original time window.
 
 Every URL serialises the full query state (filters, group-by, aggregates,
 time range, granularity) so shared links reproduce the view.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -31,6 +32,7 @@ func (rt *Router) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/span-names", rt.listSpanNames)
 	mux.HandleFunc("GET /api/logs/search", rt.searchLogs)
 	mux.HandleFunc("POST /api/query", rt.runQuery)
+	mux.HandleFunc("GET /api/history", rt.listHistory)
 	mux.HandleFunc("POST /api/clear", rt.clear)
 }
 
@@ -55,7 +57,44 @@ func (rt *Router) runQuery(w http.ResponseWriter, r *http.Request) {
 		rt.writeError(w, err)
 		return
 	}
+	// Record the run in query_history (best-effort — don't fail the user
+	// query on a history bookkeeping error). Skip raw-rows mode; a bare
+	// "browse the table" isn't something the user wants back in their
+	// recent-queries list.
+	if len(q.Select) > 0 {
+		rt.recordHistory(r.Context(), &q)
+	}
 	writeJSON(w, http.StatusOK, res)
+}
+
+func (rt *Router) recordHistory(ctx context.Context, q *query.Query) {
+	hash, err := query.HashQuery(q)
+	if err != nil {
+		rt.log.Debug("history hash failed", "err", err)
+		return
+	}
+	raw, err := json.Marshal(q)
+	if err != nil {
+		rt.log.Debug("history marshal failed", "err", err)
+		return
+	}
+	display := query.FormatDisplay(q)
+	if err := rt.store.RecordQueryRun(ctx, string(q.Dataset), string(raw), display, hash); err != nil {
+		rt.log.Debug("history write failed", "err", err)
+	}
+}
+
+func (rt *Router) listHistory(w http.ResponseWriter, r *http.Request) {
+	limit := parseInt(r.URL.Query().Get("limit"), 100)
+	entries, err := rt.store.ListQueryHistory(r.Context(), limit)
+	if err != nil {
+		rt.writeError(w, err)
+		return
+	}
+	if entries == nil {
+		entries = []store.QueryHistoryEntry{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"entries": entries})
 }
 
 func (rt *Router) listServices(w http.ResponseWriter, r *http.Request) {

--- a/internal/query/display.go
+++ b/internal/query/display.go
@@ -1,0 +1,137 @@
+package query
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FormatDisplay produces a single-line, Honeycomb-style one-glance summary
+// of a query for the history list view — "SELECT COUNT WHERE x = y GROUP
+// BY z". It's intentionally lossy: SELECTs collapse multiple aggregations
+// into a comma list, filter values render via %v, HAVING/ORDER BY aren't
+// surfaced. If you want the full AST, rehydrate from query_json.
+func FormatDisplay(q *Query) string {
+	var parts []string
+	parts = append(parts, "SELECT "+formatSelect(q.Select))
+	if len(q.Where) > 0 {
+		parts = append(parts, "WHERE "+formatFilters(q.Where))
+	}
+	if len(q.GroupBy) > 0 {
+		parts = append(parts, "GROUP BY "+strings.Join(q.GroupBy, ", "))
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatSelect(sels []Aggregation) string {
+	if len(sels) == 0 {
+		return "*" // raw-rows mode — no aggregation
+	}
+	out := make([]string, 0, len(sels))
+	for _, a := range sels {
+		if a.Field == "" {
+			out = append(out, strings.ToUpper(string(a.Op)))
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s(%s)", strings.ToUpper(string(a.Op)), a.Field))
+	}
+	return strings.Join(out, ", ")
+}
+
+func formatFilters(fs []Filter) string {
+	out := make([]string, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, formatFilter(f))
+	}
+	return strings.Join(out, " AND ")
+}
+
+func formatFilter(f Filter) string {
+	switch f.Op {
+	case FilterExists:
+		return f.Field + " exists"
+	case FilterNotExist:
+		return f.Field + " !exists"
+	case FilterIn, FilterNotIn:
+		return fmt.Sprintf("%s %s %v", f.Field, f.Op, f.Value)
+	default:
+		return fmt.Sprintf("%s %s %v", f.Field, f.Op, f.Value)
+	}
+}
+
+// HashQuery returns a stable content hash of the query suitable for
+// query_history deduplication. Time-range bounds are excluded — two runs
+// of "same query, different wall-clock window" dedupe to one history
+// row. BucketMS and granularity (if present) are included because
+// they're meaningful to the result shape.
+func HashQuery(q *Query) ([]byte, error) {
+	canonical, err := canonicalize(q)
+	if err != nil {
+		return nil, err
+	}
+	return sha256Sum(canonical), nil
+}
+
+// canonicalize emits a deterministic JSON representation suitable for
+// hashing: stable field ordering, time-range stripped, filters and group
+// keys sorted.
+func canonicalize(q *Query) ([]byte, error) {
+	type canonFilter struct {
+		Field string `json:"field"`
+		Op    string `json:"op"`
+		Value any    `json:"value,omitempty"`
+	}
+	type canonAgg struct {
+		Op    string `json:"op"`
+		Field string `json:"field,omitempty"`
+		Alias string `json:"alias,omitempty"`
+	}
+	type canonOrder struct {
+		Field string `json:"field"`
+		Dir   string `json:"dir,omitempty"`
+	}
+	type canonQuery struct {
+		Dataset  string        `json:"dataset"`
+		Select   []canonAgg    `json:"select,omitempty"`
+		Where    []canonFilter `json:"where,omitempty"`
+		GroupBy  []string      `json:"group_by,omitempty"`
+		OrderBy  []canonOrder  `json:"order_by,omitempty"`
+		Having   []canonFilter `json:"having,omitempty"`
+		Limit    int           `json:"limit,omitempty"`
+		BucketMS int64         `json:"bucket_ms,omitempty"`
+	}
+	c := canonQuery{
+		Dataset:  string(q.Dataset),
+		GroupBy:  append([]string(nil), q.GroupBy...),
+		Limit:    q.Limit,
+		BucketMS: q.BucketMS,
+	}
+	sort.Strings(c.GroupBy)
+	for _, a := range q.Select {
+		c.Select = append(c.Select, canonAgg{Op: string(a.Op), Field: a.Field, Alias: a.Alias})
+	}
+	// SELECT is order-sensitive (drives output columns), do NOT sort.
+	for _, f := range q.Where {
+		c.Where = append(c.Where, canonFilter{Field: f.Field, Op: string(f.Op), Value: f.Value})
+	}
+	sort.Slice(c.Where, func(i, j int) bool {
+		if c.Where[i].Field != c.Where[j].Field {
+			return c.Where[i].Field < c.Where[j].Field
+		}
+		return c.Where[i].Op < c.Where[j].Op
+	})
+	for _, f := range q.Having {
+		c.Having = append(c.Having, canonFilter{Field: f.Field, Op: string(f.Op), Value: f.Value})
+	}
+	sort.Slice(c.Having, func(i, j int) bool {
+		if c.Having[i].Field != c.Having[j].Field {
+			return c.Having[i].Field < c.Having[j].Field
+		}
+		return c.Having[i].Op < c.Having[j].Op
+	})
+	for _, o := range q.OrderBy {
+		c.OrderBy = append(c.OrderBy, canonOrder{Field: o.Field, Dir: o.Dir})
+	}
+	return json.Marshal(c)
+}

--- a/internal/query/hash.go
+++ b/internal/query/hash.go
@@ -1,0 +1,8 @@
+package query
+
+import "crypto/sha256"
+
+func sha256Sum(b []byte) []byte {
+	sum := sha256.Sum256(b)
+	return sum[:]
+}

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -224,6 +224,20 @@ type QueryResult struct {
 	GroupKeys []string      `json:"group_keys,omitempty"`
 }
 
+// QueryHistoryEntry is one dedup'd row in the query_history table — the
+// user has run this exact query AST `RunCount` times between FirstRunNS
+// and LastRunNS. `QueryJSON` is the canonical AST the UI rehydrates a
+// URL from; `DisplayText` is the one-glance summary for list views.
+type QueryHistoryEntry struct {
+	ID          int64  `json:"id"`
+	Dataset     string `json:"dataset"`
+	QueryJSON   string `json:"query_json"`
+	DisplayText string `json:"display_text"`
+	RunCount    int64  `json:"run_count"`
+	FirstRunNS  int64  `json:"first_run_ns"`
+	LastRunNS   int64  `json:"last_run_ns"`
+}
+
 type LogOut struct {
 	LogID          int64  `json:"log_id"`
 	TimeNS         int64  `json:"time_ns"`

--- a/internal/store/sqlite/queries.go
+++ b/internal/store/sqlite/queries.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/danielloader/waggle/internal/store"
 )
@@ -1202,6 +1203,67 @@ func nullStr(s string) any {
 		return nil
 	}
 	return s
+}
+
+// Cap on query_history rows kept before prune-on-insert. 500 is generous
+// for a single-user dev tool — every list view only hits last_run_ns DESC
+// so the tail is cheap to drop.
+const queryHistoryCap = 500
+
+// RecordQueryRun upserts a query_history row keyed by the content hash.
+// First run inserts with run_count = 1; subsequent runs update
+// last_run_ns and increment run_count. When the table crosses
+// queryHistoryCap rows, the oldest entries by last_run_ns are trimmed.
+func (s *Store) RecordQueryRun(ctx context.Context, dataset, queryJSON, displayText string, hash []byte) error {
+	now := time.Now().UnixNano()
+	// SQLite's ON CONFLICT/UPSERT needs the unique index on hash, which
+	// schema.sql sets via the UNIQUE constraint on the column.
+	const upsert = `INSERT INTO query_history
+			(dataset, hash, query_json, display_text, run_count, first_run_ns, last_run_ns)
+			VALUES (?, ?, ?, ?, 1, ?, ?)
+		ON CONFLICT(hash) DO UPDATE SET
+			run_count = run_count + 1,
+			last_run_ns = excluded.last_run_ns,
+			-- Dataset/display_text/query_json can drift if the formatter
+			-- changes between runs; keep the latest.
+			dataset = excluded.dataset,
+			display_text = excluded.display_text,
+			query_json = excluded.query_json`
+	if _, err := s.writer.ExecContext(ctx, upsert, dataset, hash, queryJSON, displayText, now, now); err != nil {
+		return fmt.Errorf("record query history: %w", err)
+	}
+	// Prune to cap. Cheap: bounded by queryHistoryCap + insert rate.
+	const prune = `DELETE FROM query_history WHERE id IN (
+		SELECT id FROM query_history ORDER BY last_run_ns DESC LIMIT -1 OFFSET ?
+	)`
+	if _, err := s.writer.ExecContext(ctx, prune, queryHistoryCap); err != nil {
+		return fmt.Errorf("prune query history: %w", err)
+	}
+	return nil
+}
+
+// ListQueryHistory returns rows ordered by last_run_ns DESC, capped at limit.
+func (s *Store) ListQueryHistory(ctx context.Context, limit int) ([]store.QueryHistoryEntry, error) {
+	if limit <= 0 || limit > queryHistoryCap {
+		limit = 100
+	}
+	const q = `SELECT id, dataset, query_json, display_text, run_count, first_run_ns, last_run_ns
+		FROM query_history ORDER BY last_run_ns DESC LIMIT ?`
+	rows, err := s.reader.QueryContext(ctx, q, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.QueryHistoryEntry
+	for rows.Next() {
+		var e store.QueryHistoryEntry
+		if err := rows.Scan(&e.ID, &e.Dataset, &e.QueryJSON, &e.DisplayText,
+			&e.RunCount, &e.FirstRunNS, &e.LastRunNS); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
 }
 
 func nullBytes(b []byte) any {

--- a/internal/store/sqlite/schema.sql
+++ b/internal/store/sqlite/schema.sql
@@ -253,3 +253,25 @@ CREATE TABLE IF NOT EXISTS attribute_values (
 ) STRICT, WITHOUT ROWID;
 
 CREATE INDEX IF NOT EXISTS idx_attrvals_lookup ON attribute_values(signal_type, service_name, key, count DESC);
+
+-- =========================================================================
+-- Query history — one row per distinct query AST the user has run, with
+-- run-count + last-run-time rolled up so repeats update the existing row
+-- instead of piling on new ones. The `hash` is a stable content hash of
+-- `query_json` so the UNIQUE key dedupes "same query" regardless of
+-- wall-clock submission time. `display_text` is a pre-rendered one-glance
+-- summary ("SELECT COUNT WHERE … GROUP BY …") so the list view doesn't
+-- need to rehydrate + format on every render.
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS query_history (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    dataset       TEXT NOT NULL,
+    hash          BLOB NOT NULL UNIQUE,
+    query_json    TEXT NOT NULL,
+    display_text  TEXT NOT NULL,
+    run_count     INTEGER NOT NULL DEFAULT 1,
+    first_run_ns  INTEGER NOT NULL,
+    last_run_ns   INTEGER NOT NULL
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_query_history_last ON query_history(last_run_ns DESC);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -62,6 +62,19 @@ type Store interface {
 	// post-scan transform.
 	RunQuery(ctx context.Context, sql string, args []any, columns []QueryColumn, hasBucket bool, groupKeys []string, rates []QueryRateSpec) (QueryResult, error)
 
+	// RecordQueryRun upserts a row in query_history keyed by the AST's
+	// content hash: first insert stamps first_run_ns/last_run_ns = now and
+	// run_count = 1; subsequent runs of the same AST update last_run_ns
+	// and increment run_count. DisplayText is the pre-rendered list-view
+	// summary ("SELECT COUNT WHERE … GROUP BY …"). Errors are fatal to the
+	// caller only if it wants them to be — the query itself has already
+	// succeeded by the time this fires.
+	RecordQueryRun(ctx context.Context, dataset, queryJSON, displayText string, hash []byte) error
+	// ListQueryHistory returns rows ordered by last_run_ns DESC, capped at
+	// `limit`. No cursor pagination yet — the set is bounded by the prune
+	// cap in RecordQueryRun.
+	ListQueryHistory(ctx context.Context, limit int) ([]QueryHistoryEntry, error)
+
 	Retain(ctx context.Context, olderThanNS int64) error
 	Clear(ctx context.Context) error
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -132,4 +132,20 @@ export const api = {
       `/api/logs/search?${params.toString()}`,
       signal,
     ),
+
+  listHistory: (limit: number, signal?: AbortSignal) =>
+    getJSON<{ entries: QueryHistoryEntry[] }>(
+      `/api/history?limit=${limit}`,
+      signal,
+    ),
 };
+
+export interface QueryHistoryEntry {
+  id: number;
+  dataset: string;
+  query_json: string;
+  display_text: string;
+  run_count: number;
+  first_run_ns: number;
+  last_run_ns: number;
+}

--- a/ui/src/lib/query.ts
+++ b/ui/src/lib/query.ts
@@ -555,3 +555,27 @@ export function summarizeOrderBy(o: Order[]): string {
   if (o.length === 0) return "None";
   return o.map((x) => `${x.field} ${x.dir ?? "desc"}`).join(", ");
 }
+
+/**
+ * Rebuild a QuerySearch URL shape from a stored Query AST (from
+ * /api/history). Re-runs use the original absolute time window; users
+ * re-preset by clicking the Last-1h pill. Dataset/bucket_ms/group_by
+ * round-trip exactly; tab defaults to "overview" (we don't persist the
+ * active tab in history). Returns a partial suitable for TanStack
+ * Router's search param.
+ */
+export function queryToUrlSearch(q: Query): Partial<QuerySearch> {
+  const fromMs = q.time_range?.from ? new Date(q.time_range.from).getTime() : undefined;
+  const toMs = q.time_range?.to ? new Date(q.time_range.to).getTime() : undefined;
+  return {
+    dataset: q.dataset,
+    from: fromMs,
+    to: toMs,
+    select: q.select ?? [],
+    where: q.where ?? [],
+    group_by: q.group_by ?? [],
+    order_by: q.order_by ?? [],
+    having: q.having ?? [],
+    ...(q.limit !== undefined ? { limit: q.limit } : {}),
+  };
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -7,6 +7,7 @@ import {
 import { z } from "zod";
 import { RootLayout } from "./routes/root";
 import { EventsPage } from "./routes/EventsPage";
+import { HistoryPage } from "./routes/HistoryPage";
 import { TraceView } from "./features/traces/TraceView";
 import { querySearchSchema } from "./lib/query";
 
@@ -57,6 +58,13 @@ const metricsRedirect = createRoute({
   component: () => <Navigate to="/events" search={{ dataset: "metrics" }} replace />,
 });
 
+// Query history — dedup'd list of recent queries, rehydrate + re-run.
+const historyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/history",
+  component: HistoryPage,
+});
+
 // Trace-detail waterfall — specialised view, kept outside the unified page.
 const traceDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -75,6 +83,7 @@ const routeTree = rootRoute.addChildren([
   tracesRedirect,
   logsRedirect,
   metricsRedirect,
+  historyRoute,
   traceDetailRoute,
 ]);
 

--- a/ui/src/routes/HistoryPage.tsx
+++ b/ui/src/routes/HistoryPage.tsx
@@ -1,0 +1,174 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Repeat } from "lucide-react";
+import { api, type QueryHistoryEntry } from "../lib/api";
+import { queryToUrlSearch, type Query } from "../lib/query";
+
+/**
+ * Query history — Honeycomb-style "Recent Queries" tab. One row per
+ * dedup'd AST, most-recent-first, showing dataset + one-glance summary
+ * + relative timestamp + run count. Click a row to re-run the stored
+ * query with the original time window; the chart preview on each row is
+ * intentionally absent in this pass (rehydrating and running every row
+ * on list-render would cost a query per row).
+ */
+export function HistoryPage() {
+  const navigate = useNavigate();
+  const q = useQuery({
+    queryKey: ["history"],
+    queryFn: ({ signal }) => api.listHistory(100, signal),
+    staleTime: 10_000,
+  });
+
+  return (
+    <div className="h-full flex flex-col">
+      <div
+        className="px-6 py-4 border-b"
+        style={{ borderColor: "var(--color-border)" }}
+      >
+        <h1 className="text-xl font-semibold">Query History</h1>
+        <p
+          className="text-sm mt-1"
+          style={{ color: "var(--color-ink-muted)" }}
+        >
+          Recent queries, deduplicated. Click a row to re-run with the
+          original time window.
+        </p>
+      </div>
+      <div className="flex-1 overflow-auto px-6 py-4">
+        {q.isPending && (
+          <div
+            className="text-sm py-8 text-center"
+            style={{ color: "var(--color-ink-muted)" }}
+          >
+            Loading…
+          </div>
+        )}
+        {q.isError && (
+          <div
+            className="text-sm py-8 text-center"
+            style={{ color: "var(--color-error)" }}
+          >
+            Error: {(q.error as Error).message}
+          </div>
+        )}
+        {q.data && q.data.entries.length === 0 && (
+          <div
+            className="text-sm py-8 text-center"
+            style={{ color: "var(--color-ink-muted)" }}
+          >
+            No history yet. Run a query on the Events page and come back.
+          </div>
+        )}
+        {q.data && q.data.entries.length > 0 && (
+          <ul className="flex flex-col gap-2">
+            {q.data.entries.map((e) => (
+              <HistoryRow
+                key={e.id}
+                entry={e}
+                onClick={() => {
+                  const query = safeParseQuery(e.query_json);
+                  if (!query) return;
+                  const search = queryToUrlSearch(query);
+                  navigate({
+                    to: "/events",
+                    search: search as unknown as Record<string, unknown>,
+                  });
+                }}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HistoryRow({
+  entry,
+  onClick,
+}: {
+  entry: QueryHistoryEntry;
+  onClick: () => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        className="w-full text-left rounded-md border px-4 py-3 hover:bg-[var(--color-card-hover)] flex items-start gap-4"
+        style={{
+          borderColor: "var(--color-border)",
+          background: "var(--color-card)",
+        }}
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1.5">
+            <DatasetPill dataset={entry.dataset} />
+            <span
+              className="text-xs"
+              style={{ color: "var(--color-ink-muted)" }}
+            >
+              {relativeTime(entry.last_run_ns)}
+            </span>
+            {entry.run_count > 1 && (
+              <span
+                className="inline-flex items-center gap-1 text-[10px] tabular-nums px-1.5 py-0.5 rounded"
+                style={{
+                  color: "var(--color-ink-muted)",
+                  background: "var(--color-surface-muted)",
+                }}
+                title={`Run ${entry.run_count} times`}
+              >
+                <Repeat className="w-3 h-3" />
+                {entry.run_count}
+              </span>
+            )}
+          </div>
+          <div className="font-mono text-xs leading-relaxed break-words whitespace-pre-wrap">
+            {entry.display_text}
+          </div>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function DatasetPill({ dataset }: { dataset: string }) {
+  return (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wider"
+      style={{
+        background: "color-mix(in srgb, var(--color-accent) 14%, transparent)",
+        color: "var(--color-accent)",
+      }}
+    >
+      {dataset}
+    </span>
+  );
+}
+
+// Convert a nanosecond wall-clock stamp into a short "X minutes ago"
+// relative label. Honeycomb does the same on their recent-queries list.
+function relativeTime(ns: number): string {
+  const nowMs = Date.now();
+  const ms = ns / 1e6;
+  const diff = Math.max(0, nowMs - ms);
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+function safeParseQuery(json: string): Query | null {
+  try {
+    return JSON.parse(json) as Query;
+  } catch {
+    return null;
+  }
+}

--- a/ui/src/routes/HistoryPage.tsx
+++ b/ui/src/routes/HistoryPage.tsx
@@ -98,7 +98,7 @@ function HistoryRow({
       <button
         type="button"
         onClick={onClick}
-        className="w-full text-left rounded-md border px-4 py-3 hover:bg-[var(--color-card-hover)] flex items-start gap-4"
+        className="w-full text-left rounded-md border px-4 py-3 cursor-pointer hover:bg-[var(--color-card-hover)] flex items-start gap-4"
         style={{
           borderColor: "var(--color-border)",
           background: "var(--color-card)",

--- a/ui/src/routes/HistoryPage.tsx
+++ b/ui/src/routes/HistoryPage.tsx
@@ -91,6 +91,8 @@ function HistoryRow({
   entry: QueryHistoryEntry;
   onClick: () => void;
 }) {
+  const query = safeParseQuery(entry.query_json);
+  const windowLabel = query ? formatWindow(query) : null;
   return (
     <li>
       <button
@@ -103,7 +105,7 @@ function HistoryRow({
         }}
       >
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1.5">
+          <div className="flex items-center gap-2 mb-1.5 flex-wrap">
             <DatasetPill dataset={entry.dataset} />
             <span
               className="text-xs"
@@ -111,6 +113,15 @@ function HistoryRow({
             >
               {relativeTime(entry.last_run_ns)}
             </span>
+            {windowLabel && (
+              <span
+                className="text-xs tabular-nums"
+                style={{ color: "var(--color-ink-muted)" }}
+                title="Time window the query ran against"
+              >
+                · {windowLabel}
+              </span>
+            )}
             {entry.run_count > 1 && (
               <span
                 className="inline-flex items-center gap-1 text-[10px] tabular-nums px-1.5 py-0.5 rounded"
@@ -132,6 +143,51 @@ function HistoryRow({
       </button>
     </li>
   );
+}
+
+// Format a Query's time range as "Apr 20 11:03 – 12:03 (1h)" — short
+// enough to fit on the row's metadata line, precise enough to tell the
+// user "this ran against a 1h window starting here". Falls back to an
+// empty label if the range is malformed.
+function formatWindow(q: Query): string | null {
+  const fromMs = q.time_range?.from ? new Date(q.time_range.from).getTime() : NaN;
+  const toMs = q.time_range?.to ? new Date(q.time_range.to).getTime() : NaN;
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || toMs <= fromMs) {
+    return null;
+  }
+  const from = new Date(fromMs);
+  const to = new Date(toMs);
+  const duration = humanDuration(toMs - fromMs);
+  // Same calendar day → show date once, both clocks. Different days → include
+  // date on both ends so "yesterday 23:30 – today 00:30" isn't misread.
+  const sameDay =
+    from.getFullYear() === to.getFullYear() &&
+    from.getMonth() === to.getMonth() &&
+    from.getDate() === to.getDate();
+  const datePart = `${shortMonth(from)} ${from.getDate()}`;
+  if (sameDay) {
+    return `${datePart} ${clock(from)} – ${clock(to)} (${duration})`;
+  }
+  return `${datePart} ${clock(from)} – ${shortMonth(to)} ${to.getDate()} ${clock(to)} (${duration})`;
+}
+
+function shortMonth(d: Date): string {
+  return d.toLocaleString(undefined, { month: "short" });
+}
+
+function clock(d: Date): string {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function humanDuration(ms: number): string {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = m / 60;
+  if (h < 24) return h % 1 === 0 ? `${h}h` : `${h.toFixed(1)}h`;
+  const d = h / 24;
+  return d % 1 === 0 ? `${d}d` : `${d.toFixed(1)}d`;
 }
 
 function DatasetPill({ dataset }: { dataset: string }) {

--- a/ui/src/routes/root.tsx
+++ b/ui/src/routes/root.tsx
@@ -3,6 +3,7 @@ import { Link, Outlet, useLocation } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
+  History,
   PanelLeftClose,
   PanelLeft,
 } from "lucide-react";
@@ -113,6 +114,12 @@ export function RootLayout() {
             "Events",
             <Activity />,
             pathname === "/" || pathname.startsWith("/events") || pathname === "/traces" || pathname === "/logs" || pathname === "/metrics",
+          )}
+          {navItem(
+            "/history",
+            "History",
+            <History />,
+            pathname.startsWith("/history"),
           )}
         </nav>
         <div


### PR DESCRIPTION
## Summary
Honeycomb-style **Recent Queries** panel for waggle. New \`/history\` route in the sidebar lists the user's recent structured queries, deduplicated by AST content hash, with dataset pill + time-window label + relative age + run-count badge. Clicking an entry rehydrates the URL's QuerySearch shape and navigates back to \`/events\` to re-run.

## Design choice — stored shape
Stores the canonical backend \`Query\` AST (the JSON that already hits \`/api/query\`), **not** the URL. That's the stable contract and lets us:
- dedupe repeats via a SHA-256 hash of the canonicalised AST (time range stripped so "same query, different window" collapses to one row; \`WHERE\` / \`GROUP BY\` / \`HAVING\` sorted for order-independence)
- re-render the list view from a pre-baked \`display_text\` without rehydrating each row
- recover from UI-side URL-param renames in the future (migrate on read from the AST, not from string-munging old URLs)

## Changes
- **Backend**
  - \`query_history\` table: \`id, dataset, hash UNIQUE, query_json, display_text, run_count, first_run_ns, last_run_ns\` + index on \`last_run_ns DESC\`.
  - \`RecordQueryRun\` upserts by hash; prunes to top 500 by \`last_run_ns\`.
  - \`query.HashQuery\` + \`query.FormatDisplay\` — canonical hash + one-liner summary.
  - \`POST /api/query\` records on success (skips raw-rows mode); failures are logged at debug and never fail the user query.
  - \`GET /api/history?limit=N\` returns entries ordered by last run.
- **Frontend**
  - New sidebar "History" nav item.
  - \`HistoryPage\` — dataset pill, relative timestamp, absolute time window (same-day: \`Apr 20 11:03 – 12:03 (1h)\`; cross-day: both dates), run-count badge, mono one-liner with the summary. Empty / loading / error states match the rest of the UI.
  - \`queryToUrlSearch()\` helper converts a stored Query AST back into the URL's QuerySearch shape.

## Test plan
- [x] \`go build ./...\` / \`go test ./...\` clean
- [x] \`ui/ npx tsc -b\` clean
- [x] Browser smoke: \`/api/query\` calls land in \`query_history\`, repeats bump run_count, \`/history\` renders rows with time windows, dataset pills, and run counts
- [ ] Click a history row → navigates to \`/events\` with the stored query restored and the chart/events re-fetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)