### PR TITLE
bench: 10M event loadgen, query battery, and baseline timings

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,16 @@ tasks:
     cmds:
       - go run ./cmd/loadgen {{.CLI_ARGS}}
 
+  loadgen-bulk:
+    desc: Fill a new DB with 10M synthetic events for query benchmarking (--db path --total N).
+    cmds:
+      - go run ./cmd/loadgen-bulk {{.CLI_ARGS}}
+
+  bench-queries:
+    desc: Run query timing battery against a waggle DB (--db path --runs N).
+    cmds:
+      - go run ./cmd/bench-queries {{.CLI_ARGS}}
+
   # ---------------------------------------------------------- release
   release:snapshot:
     desc: Build a snapshot release locally (archives + docker image, no publish). Requires `goreleaser` on PATH.

--- a/cmd/bench-queries/main.go
+++ b/cmd/bench-queries/main.go
@@ -1,0 +1,485 @@
+// bench-queries runs a labelled battery of SQL queries against a waggle SQLite
+// database and prints a timing table. Queries mirror the exact SQL shapes the
+// API layer produces so timings reflect real user-facing latency.
+//
+// Usage:
+//
+//	go run ./cmd/bench-queries --db ./waggle-test.db
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	sqstore "github.com/danielloader/waggle/internal/store/sqlite"
+)
+
+type queryCase struct {
+	label string
+	sql   string
+	args  []any
+}
+
+func main() {
+	dbPath := flag.String("db", "./waggle-test.db", "SQLite database path")
+	runs    := flag.Int("runs", 3, "Number of runs per query (median reported)")
+	flag.Parse()
+
+	ctx := context.Background()
+	st, err := sqstore.Open(ctx, *dbPath)
+	if err != nil {
+		log.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	db := st.ReaderDB()
+
+	// Discover data bounds so time-range queries cover real rows.
+	var minNS, maxNS int64
+	if err := db.QueryRowContext(ctx,
+		`SELECT MIN(time_ns), MAX(time_ns) FROM events`).Scan(&minNS, &maxNS); err != nil {
+		log.Fatalf("scan time bounds: %v", err)
+	}
+	spanNS := maxNS - minNS
+	midNS  := minNS + spanNS/2
+	qtrNS  := spanNS / 4
+
+	// Bucket size: 1-hour buckets (in nanoseconds) for time-series queries.
+	const hourNS = int64(time.Hour)
+
+	// A representative service name present in the data.
+	const svc = "api-gateway"
+
+	// Pre-build a trace_id BLOB sample for the single-trace lookup.
+	var sampleTraceID []byte
+	_ = db.QueryRowContext(ctx,
+		`SELECT trace_id FROM events WHERE signal_type='span' AND parent_span_id IS NULL LIMIT 1`,
+	).Scan(&sampleTraceID)
+
+	cases := []queryCase{
+		// ------------------------------------------------------------------
+		// 1. Service summary (ListServices) — spans by service with error rate
+		// ------------------------------------------------------------------
+		{
+			label: "LIST services (span count + error rate per service)",
+			sql: `SELECT service_name,
+				COUNT(*) AS total,
+				SUM(CASE WHEN status_code = 2 THEN 1 ELSE 0 END) AS errs
+				FROM events WHERE signal_type = 'span'
+				GROUP BY service_name ORDER BY total DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 2. Trace listing — root spans + correlated span-count + has_error
+		// ------------------------------------------------------------------
+		{
+			label: "LIST traces (root spans + span_count correlated subquery, LIMIT 50)",
+			sql: `WITH roots AS (
+				SELECT trace_id, span_id, service_name, name, time_ns, end_time_ns
+				FROM events
+				WHERE signal_type = 'span' AND parent_span_id IS NULL
+				ORDER BY time_ns DESC, trace_id DESC LIMIT 50)
+			SELECT r.trace_id, r.service_name, r.name, r.time_ns,
+				COALESCE(r.end_time_ns - r.time_ns, 0) AS duration_ns,
+				(SELECT COUNT(*) FROM events e WHERE e.signal_type='span' AND e.trace_id=r.trace_id) AS span_count,
+				COALESCE((SELECT 1 FROM events e WHERE e.signal_type='span' AND e.trace_id=r.trace_id AND e.status_code=2 LIMIT 1), 0) AS has_error
+			FROM roots r ORDER BY r.time_ns DESC, r.trace_id DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 3. COUNT all spans (full filtered scan)
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) all spans",
+			sql:   `SELECT COUNT(*) FROM events WHERE signal_type = 'span'`,
+		},
+
+		// ------------------------------------------------------------------
+		// 4. COUNT all logs
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) all logs",
+			sql:   `SELECT COUNT(*) FROM events WHERE signal_type = 'log'`,
+		},
+
+		// ------------------------------------------------------------------
+		// 5. COUNT all metric_events
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) all metric events",
+			sql:   `SELECT COUNT(*) FROM metric_events`,
+		},
+
+		// ------------------------------------------------------------------
+		// 6. GROUP BY service_name — span count per service
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) spans GROUP BY service_name",
+			sql: `SELECT service_name, COUNT(*) AS cnt
+				FROM events WHERE signal_type = 'span'
+				GROUP BY service_name ORDER BY cnt DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 7. GROUP BY http_route — uses idx_events_http_route
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) spans GROUP BY http_route",
+			sql: `SELECT http_route, COUNT(*) AS cnt
+				FROM events WHERE signal_type = 'span' AND http_route IS NOT NULL
+				GROUP BY http_route ORDER BY cnt DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 8. GROUP BY span_kind
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) spans GROUP BY span_kind",
+			sql: `SELECT span_kind, COUNT(*) AS cnt
+				FROM events WHERE signal_type = 'span'
+				GROUP BY span_kind ORDER BY cnt DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 9. Error count and rate per service
+		// ------------------------------------------------------------------
+		{
+			label: "Error rate per service (status_code=2)",
+			sql: `SELECT service_name,
+				COUNT(*) AS total,
+				SUM(CASE WHEN status_code = 2 THEN 1 ELSE 0 END) AS errors,
+				CAST(SUM(CASE WHEN status_code = 2 THEN 1 ELSE 0 END) AS REAL) / COUNT(*) AS error_rate
+				FROM events WHERE signal_type = 'span'
+				GROUP BY service_name ORDER BY error_rate DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 10. P95 latency by service — uses UDF percentile()
+		// ------------------------------------------------------------------
+		{
+			label: "P50/P95/P99 duration_ns by service (percentile UDF)",
+			sql: `SELECT service_name,
+				percentile(duration_ns, 0.50) AS p50_ns,
+				percentile(duration_ns, 0.95) AS p95_ns,
+				percentile(duration_ns, 0.99) AS p99_ns
+				FROM events WHERE signal_type = 'span'
+				GROUP BY service_name ORDER BY p95_ns DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 11. Time-bucketed span count (1-hour buckets, full window)
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) spans bucketed by 1h over full window",
+			sql: fmt.Sprintf(`SELECT (time_ns / %d) * %d AS bucket_ns, COUNT(*) AS cnt
+				FROM events WHERE signal_type='span' AND time_ns >= ? AND time_ns < ?
+				GROUP BY bucket_ns ORDER BY bucket_ns ASC`, hourNS, hourNS),
+			args: []any{minNS, maxNS},
+		},
+
+		// ------------------------------------------------------------------
+		// 12. Time-bucketed + GROUP BY service (multi-series chart)
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) spans bucketed 1h + GROUP BY service (multi-series)",
+			sql: fmt.Sprintf(`SELECT (time_ns / %d) * %d AS bucket_ns, service_name, COUNT(*) AS cnt
+				FROM events WHERE signal_type='span' AND time_ns >= ? AND time_ns < ?
+				GROUP BY bucket_ns, service_name ORDER BY bucket_ns ASC`, hourNS, hourNS),
+			args: []any{minNS, maxNS},
+		},
+
+		// ------------------------------------------------------------------
+		// 13. P95 latency bucketed by 1h (time-series percentile)
+		// ------------------------------------------------------------------
+		{
+			label: "P95 duration_ns bucketed 1h (percentile time-series)",
+			sql: fmt.Sprintf(`SELECT (time_ns / %d) * %d AS bucket_ns,
+				percentile(duration_ns, 0.95) AS p95_ns
+				FROM events WHERE signal_type='span' AND time_ns >= ? AND time_ns < ?
+				GROUP BY bucket_ns ORDER BY bucket_ns ASC`, hourNS, hourNS),
+			args: []any{minNS, maxNS},
+		},
+
+		// ------------------------------------------------------------------
+		// 14. Raw rows: latest 500 spans (typical events-list page load)
+		// ------------------------------------------------------------------
+		{
+			label: "Raw span rows LIMIT 500 ORDER BY time DESC",
+			sql: `SELECT hex(trace_id), hex(span_id), hex(parent_span_id),
+				service_name, name, span_kind, time_ns, duration_ns,
+				COALESCE(status_code, 0), attributes
+				FROM events WHERE signal_type = 'span'
+				ORDER BY time_ns DESC LIMIT 500`,
+		},
+
+		// ------------------------------------------------------------------
+		// 15. Filtered by service + time range (quarter of the window)
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) spans filtered by service + quarter-window time range",
+			sql: `SELECT COUNT(*) FROM events
+				WHERE signal_type = 'span' AND service_name = ? AND time_ns >= ? AND time_ns < ?`,
+			args: []any{svc, midNS - qtrNS, midNS + qtrNS},
+		},
+
+		// ------------------------------------------------------------------
+		// 16. Filtered by http_route exact match
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) spans WHERE http_route = '/users'",
+			sql: `SELECT COUNT(*) FROM events
+				WHERE signal_type = 'span' AND http_route = '/users'`,
+		},
+
+		// ------------------------------------------------------------------
+		// 17. Single trace fetch (span waterfall) — uses idx_events_trace
+		// ------------------------------------------------------------------
+		{
+			label: "GET single trace (all spans for one trace_id)",
+			sql: `SELECT event_id, time_ns, end_time_ns, service_name, name,
+				span_kind, COALESCE(status_code, 0), attributes, hex(trace_id), hex(span_id), hex(parent_span_id)
+				FROM events WHERE signal_type = 'span' AND trace_id = ?`,
+			args: []any{sampleTraceID},
+		},
+
+		// ------------------------------------------------------------------
+		// 18. Log events: COUNT by severity
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) logs GROUP BY severity_text",
+			sql: `SELECT severity_text, COUNT(*) AS cnt
+				FROM events WHERE signal_type = 'log'
+				GROUP BY severity_text ORDER BY cnt DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 19. Log raw rows LIMIT 500
+		// ------------------------------------------------------------------
+		{
+			label: "Raw log rows LIMIT 500 ORDER BY time DESC",
+			sql: `SELECT time_ns, service_name, severity_number, severity_text, body, attributes
+				FROM events WHERE signal_type = 'log'
+				ORDER BY time_ns DESC LIMIT 500`,
+		},
+
+		// ------------------------------------------------------------------
+		// 20. FTS log search
+		// ------------------------------------------------------------------
+		{
+			label: "FTS log search: body MATCH 'payment'",
+			sql: `SELECT e.time_ns, e.service_name, e.severity_text, e.body
+				FROM events e
+				JOIN events_fts ON events_fts.rowid = e.event_id
+				WHERE events_fts MATCH 'payment' AND e.signal_type = 'log'
+				ORDER BY e.time_ns DESC LIMIT 100`,
+		},
+
+		// ------------------------------------------------------------------
+		// 21. Metric COUNT by service
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) metric_events GROUP BY service_name",
+			sql: `SELECT service_name, COUNT(*) AS cnt
+				FROM metric_events GROUP BY service_name ORDER BY cnt DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 22. Metric aggregation: MAX(requests.total) by service
+		// ------------------------------------------------------------------
+		{
+			label: "MAX(requests.total) metric GROUP BY service_name (json_extract)",
+			sql: `SELECT service_name,
+				MAX(CAST(json_extract(attributes, '$."requests.total"') AS INTEGER)) AS max_requests,
+				AVG(CAST(json_extract(attributes, '$."cpu.utilization"') AS REAL)) AS avg_cpu
+				FROM metric_events GROUP BY service_name ORDER BY max_requests DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 23. Metric time-series: AVG(cpu.utilization) bucketed 1h
+		// ------------------------------------------------------------------
+		{
+			label: "AVG(cpu.utilization) metric bucketed 1h (json_extract)",
+			sql: fmt.Sprintf(`SELECT (time_ns / %d) * %d AS bucket_ns,
+				AVG(CAST(json_extract(attributes, '$."cpu.utilization"') AS REAL)) AS avg_cpu
+				FROM metric_events WHERE time_ns >= ? AND time_ns < ?
+				GROUP BY bucket_ns ORDER BY bucket_ns ASC`, hourNS, hourNS),
+			args: []any{minNS, maxNS},
+		},
+
+		// ------------------------------------------------------------------
+		// 24. json_extract filter: WHERE component = 'middleware'
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) spans WHERE json_extract(attributes, '$.component') = 'middleware'",
+			sql: `SELECT COUNT(*) FROM events
+				WHERE signal_type = 'span'
+				AND json_extract(attributes, '$."component"') = 'middleware'`,
+		},
+
+		// ------------------------------------------------------------------
+		// 25. COUNT DISTINCT trace_id (cardinality)
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(DISTINCT trace_id) — trace cardinality",
+			sql:   `SELECT COUNT(DISTINCT trace_id) FROM events WHERE signal_type = 'span'`,
+		},
+
+		// ------------------------------------------------------------------
+		// 26. Root-span only (idx_events_roots partial index)
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) root spans only (partial index on parent_span_id IS NULL)",
+			sql: `SELECT COUNT(*) FROM events
+				WHERE signal_type = 'span' AND parent_span_id IS NULL`,
+		},
+
+		// ------------------------------------------------------------------
+		// 27. Slowest spans (ORDER BY duration_ns DESC LIMIT 100)
+		// ------------------------------------------------------------------
+		{
+			label: "Top-100 slowest spans (ORDER BY duration_ns DESC)",
+			sql: `SELECT service_name, name, duration_ns, time_ns, attributes
+				FROM events WHERE signal_type = 'span'
+				ORDER BY duration_ns DESC LIMIT 100`,
+		},
+
+		// ------------------------------------------------------------------
+		// 28. Error spans across all services
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) + AVG duration of ERROR spans (status_code=2) by service",
+			sql: `SELECT service_name, COUNT(*) AS err_count,
+				AVG(duration_ns) AS avg_duration_ns
+				FROM events WHERE signal_type = 'span' AND status_code = 2
+				GROUP BY service_name ORDER BY err_count DESC`,
+		},
+
+		// ------------------------------------------------------------------
+		// 29. Field catalog (attribute_keys)
+		// ------------------------------------------------------------------
+		{
+			label: "LIST attribute_keys for spans (field catalog)",
+			sql: `SELECT key, value_type, count FROM attribute_keys
+				WHERE signal_type = 'span' ORDER BY count DESC LIMIT 100`,
+		},
+
+		// ------------------------------------------------------------------
+		// 30. Heavy: COUNT(*) all events regardless of signal type
+		// ------------------------------------------------------------------
+		{
+			label: "COUNT(*) entire events table (all signals)",
+			sql:   `SELECT COUNT(*) FROM events`,
+		},
+	}
+
+	type result struct {
+		label   string
+		timings []time.Duration
+		rows    int64
+	}
+
+	results := make([]result, len(cases))
+
+	for i, c := range cases {
+		r := result{label: c.label}
+		for run := range *runs {
+			t0 := time.Now()
+			n, err := runQuery(ctx, db, c.sql, c.args)
+			elapsed := time.Since(t0)
+			if err != nil {
+				log.Printf("[%d] %s: ERROR: %v", i+1, c.label, err)
+				break
+			}
+			if run == 0 {
+				r.rows = n
+			}
+			r.timings = append(r.timings, elapsed)
+		}
+		results[i] = r
+		med := median(r.timings)
+		fmt.Printf("[%2d/%d] %-70s  rows=%-8d  %s\n",
+			i+1, len(cases), truncate(c.label, 70), r.rows, med.Round(time.Millisecond))
+	}
+
+	// Summary table
+	fmt.Println()
+	fmt.Println(strings.Repeat("=", 110))
+	fmt.Println("QUERY BENCHMARK SUMMARY")
+	fmt.Println(strings.Repeat("=", 110))
+	w := tabwriter.NewWriter(nil, 0, 0, 2, ' ', 0)
+	w = tabwriter.NewWriter(
+		// Wrap to stdout
+		writerFn(func(p []byte) (int, error) { fmt.Print(string(p)); return len(p), nil }),
+		0, 0, 2, ' ', 0,
+	)
+	fmt.Fprintln(w, "#\tLabel\tRows\tMin\tMedian\tMax")
+	fmt.Fprintln(w, "-\t-----\t----\t---\t------\t---")
+	for i, r := range results {
+		if len(r.timings) == 0 {
+			fmt.Fprintf(w, "%d\t%s\t%d\tERROR\tERROR\tERROR\n",
+				i+1, truncate(r.label, 72), r.rows)
+			continue
+		}
+		mn, med, mx := stats(r.timings)
+		fmt.Fprintf(w, "%d\t%s\t%d\t%s\t%s\t%s\n",
+			i+1, truncate(r.label, 72), r.rows,
+			mn.Round(time.Millisecond),
+			med.Round(time.Millisecond),
+			mx.Round(time.Millisecond))
+	}
+	w.Flush()
+}
+
+// runQuery executes a SELECT, drains the rows, and returns the row count.
+func runQuery(ctx context.Context, db *sql.DB, query string, args []any) (int64, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var n int64
+	for rows.Next() {
+		n++
+	}
+	return n, rows.Err()
+}
+
+func median(d []time.Duration) time.Duration {
+	if len(d) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), d...)
+	sortDurations(sorted)
+	return sorted[len(sorted)/2]
+}
+
+func stats(d []time.Duration) (min, med, max time.Duration) {
+	sorted := append([]time.Duration(nil), d...)
+	sortDurations(sorted)
+	return sorted[0], sorted[len(sorted)/2], sorted[len(sorted)-1]
+}
+
+func sortDurations(d []time.Duration) {
+	for i := 1; i < len(d); i++ {
+		for j := i; j > 0 && d[j] < d[j-1]; j-- {
+			d[j], d[j-1] = d[j-1], d[j]
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+type writerFn func([]byte) (int, error)
+
+func (f writerFn) Write(p []byte) (int, error) { return f(p) }

--- a/cmd/loadgen-bulk/main.go
+++ b/cmd/loadgen-bulk/main.go
@@ -1,0 +1,597 @@
+// loadgen-bulk fills a fresh SQLite database with synthetic OTLP-shaped events
+// by writing directly to the store, bypassing the HTTP ingest path. Intended
+// for query-performance benchmarking on realistic data volumes.
+//
+// Usage:
+//
+//	go run ./cmd/loadgen-bulk --db ./waggle-test.db --total 10000000
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"os"
+	"time"
+
+	"github.com/danielloader/waggle/internal/store"
+	sqstore "github.com/danielloader/waggle/internal/store/sqlite"
+)
+
+var serviceNames = [8]string{
+	"api-gateway", "order-service", "payment-service", "user-service",
+	"inventory-service", "notification-service", "analytics-service", "auth-service",
+}
+
+const numInstances = 2 // resource instances per service → 16 resources total
+
+var (
+	httpMethods = [5]string{"GET", "POST", "PUT", "DELETE", "PATCH"}
+
+	httpRoutes = [24]string{
+		"/users", "/users/:id", "/users/:id/profile",
+		"/orders", "/orders/:id", "/orders/:id/items", "/orders/:id/cancel",
+		"/products", "/products/:id", "/products/search",
+		"/checkout", "/checkout/confirm", "/checkout/summary",
+		"/payments", "/payments/:id", "/payments/refund",
+		"/auth/login", "/auth/logout", "/auth/refresh",
+		"/inventory/:id", "/inventory/reserve",
+		"/notifications/send", "/health", "/ready",
+	}
+
+	dbSystems = [4]string{"postgresql", "mysql", "redis", "elasticsearch"}
+
+	dbStatements = [6]string{
+		"SELECT * FROM users WHERE id = $1",
+		"INSERT INTO orders (user_id, total) VALUES ($1, $2)",
+		"UPDATE inventory SET quantity = quantity - $1 WHERE product_id = $2",
+		"SELECT COUNT(*) FROM events WHERE created_at > $1",
+		"DELETE FROM sessions WHERE expires_at < NOW()",
+		"SELECT * FROM products WHERE category = $1 LIMIT $2",
+	}
+
+	rpcServices = [6]string{
+		"OrderService", "PaymentService", "UserService",
+		"InventoryService", "NotificationService", "AuthService",
+	}
+
+	rpcMethods = [8]string{
+		"Create", "Get", "List", "Update",
+		"Authorize", "Process", "Validate", "Send",
+	}
+
+	logBodies = [15]string{
+		"request received",
+		"order processing completed",
+		"payment authorized",
+		"cache miss: fetching from db",
+		"db query completed",
+		"request succeeded",
+		"validation failed: missing field",
+		"rate limit exceeded",
+		"background job started",
+		"background job completed",
+		"health check passed",
+		"configuration reloaded",
+		"connection pool at capacity",
+		"retry: downstream unavailable",
+		"circuit breaker opened",
+	}
+
+	// severity pool biased towards INFO (indices 1-3)
+	severityNums  = [6]int32{5, 9, 9, 9, 13, 17}
+	severityTexts = [6]string{"DEBUG", "INFO", "INFO", "INFO", "WARN", "ERROR"}
+)
+
+func i32p(v int32) *int32   { return &v }
+func i64p(v int64) *int64   { return &v }
+func u32p(v uint32) *uint32 { return &v }
+
+func main() {
+	dbPath   := flag.String("db", "./waggle-test.db", "Output SQLite database path")
+	nTotal   := flag.Int("total", 10_000_000, "Total number of events to generate")
+	batchSz  := flag.Int("batch-size", 2_000, "Events per write batch")
+	seedFlag := flag.Uint64("seed", 0, "Random seed (0 = time-based)")
+	win      := flag.Duration("window", 24*time.Hour, "Time window for event timestamps")
+	spansPct := flag.Int("spans-pct", 60, "Percentage of events that are spans")
+	logsPct  := flag.Int("logs-pct", 10, "Percentage of events that are logs")
+	flag.Parse()
+
+	if *spansPct+*logsPct > 100 {
+		log.Fatalf("--spans-pct + --logs-pct must be ≤ 100")
+	}
+
+	s := *seedFlag
+	if s == 0 {
+		s = uint64(time.Now().UnixNano())
+	}
+	rng := rand.New(rand.NewPCG(s, s^0xdeadbeefcafebabe))
+
+	numSpans   := *nTotal * *spansPct / 100
+	numLogs    := *nTotal * *logsPct / 100
+	numMetrics := *nTotal - numSpans - numLogs
+	log.Printf("loadgen-bulk: db=%s  spans=%d  logs=%d  metrics=%d  total=%d",
+		*dbPath, numSpans, numLogs, numMetrics, numSpans+numLogs+numMetrics)
+
+	ctx := context.Background()
+	st, err := sqstore.Open(ctx, *dbPath)
+	if err != nil {
+		log.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	// Tune SQLite for bulk loading.
+	// Keep autocheckpoint enabled at 10k pages (~40 MB) to prevent the WAL
+	// growing unboundedly, which slows writes at multi-GB scale.
+	wrDB := st.WriterDB()
+	for _, p := range []string{
+		"PRAGMA synchronous = OFF",
+		"PRAGMA wal_autocheckpoint = 10000",
+		"PRAGMA cache_size = -131072", // 512 MB page cache
+	} {
+		if _, err := wrDB.ExecContext(ctx, p); err != nil {
+			log.Fatalf("pragma %s: %v", p, err)
+		}
+	}
+
+	// Drop FTS triggers; rebuild the index in one pass after all inserts.
+	for _, t := range []string{"events_ai", "events_ad"} {
+		if _, err := wrDB.ExecContext(ctx, "DROP TRIGGER IF EXISTS "+t); err != nil {
+			log.Fatalf("drop trigger %s: %v", t, err)
+		}
+	}
+
+	now := time.Now()
+	windowNS := win.Nanoseconds()
+
+	// ------------------------------------------------------------------
+	// Resources (8 services × 2 instances = 16) and scopes (8)
+	// ------------------------------------------------------------------
+	resources := make([]store.Resource, 0, len(serviceNames)*numInstances)
+	for si, svc := range serviceNames {
+		for inst := range numInstances {
+			id := uint64(si*numInstances + inst + 1)
+			resources = append(resources, store.Resource{
+				ID:                id,
+				ServiceName:       svc,
+				ServiceNamespace:  "production",
+				ServiceVersion:    "1.0.0",
+				ServiceInstanceID: fmt.Sprintf("%s-%d", svc, inst),
+				SDKName:           "opentelemetry",
+				SDKLanguage:       "go",
+				SDKVersion:        "1.26.0",
+				AttributesJSON:    `{"deployment.environment":"production"}`,
+				FirstSeenNS:       now.UnixNano() - windowNS,
+				LastSeenNS:        now.UnixNano(),
+			})
+		}
+	}
+
+	scopes := make([]store.Scope, len(serviceNames))
+	for si, svc := range serviceNames {
+		scopes[si] = store.Scope{
+			ID:      uint64(si + 1),
+			Name:    svc + "/instrumentation",
+			Version: "1.0.0",
+		}
+	}
+
+	// Pool for random resource → scope → service lookup.
+	type rsEntry struct {
+		resourceID  uint64
+		scopeID     uint64
+		serviceName string
+	}
+	pool := make([]rsEntry, len(resources))
+	for i, r := range resources {
+		pool[i] = rsEntry{r.ID, scopes[i/numInstances].ID, r.ServiceName}
+	}
+	pick := func() rsEntry { return pool[rng.IntN(len(pool))] }
+
+	randTimeNS := func() int64 {
+		return now.UnixNano() - windowNS + rng.Int64N(windowNS)
+	}
+	newTraceID := func() []byte {
+		b := make([]byte, 16)
+		binary.LittleEndian.PutUint64(b[:8], rng.Uint64())
+		binary.LittleEndian.PutUint64(b[8:], rng.Uint64())
+		return b
+	}
+	newSpanID := func() []byte {
+		b := make([]byte, 8)
+		binary.LittleEndian.PutUint64(b, rng.Uint64())
+		return b
+	}
+
+	// ------------------------------------------------------------------
+	// Attribute JSON helpers (fmt.Sprintf avoids reflection overhead).
+	// ------------------------------------------------------------------
+	httpSpanAttrs := func(svc, kind, method, route string, code int) string {
+		return fmt.Sprintf(
+			`{"meta.signal_type":"span","meta.span_kind":%q,"meta.dataset":%q,"http.request.method":%q,"http.route":%q,"http.response.status_code":%d}`,
+			kind, svc, method, route, code)
+	}
+	rpcSpanAttrs := func(svc, kind, rpcSvc, rpcMethod string) string {
+		return fmt.Sprintf(
+			`{"meta.signal_type":"span","meta.span_kind":%q,"meta.dataset":%q,"rpc.service":%q,"rpc.method":%q}`,
+			kind, svc, rpcSvc, rpcMethod)
+	}
+	dbSpanAttrs := func(svc, dbSys, stmt string) string {
+		return fmt.Sprintf(
+			`{"meta.signal_type":"span","meta.span_kind":"CLIENT","meta.dataset":%q,"db.system":%q,"db.statement":%q}`,
+			svc, dbSys, stmt)
+	}
+	internalSpanAttrs := func(svc, component string) string {
+		return fmt.Sprintf(
+			`{"meta.signal_type":"span","meta.span_kind":"INTERNAL","meta.dataset":%q,"component":%q}`,
+			svc, component)
+	}
+	logEventAttrs := func(svc, component string) string {
+		return fmt.Sprintf(
+			`{"meta.signal_type":"log","meta.dataset":%q,"component":%q}`,
+			svc, component)
+	}
+	metricEventAttrs := func(svc string, reqs, memUsed int64, cpu float64) string {
+		return fmt.Sprintf(
+			`{"meta.dataset":%q,"requests.total":%d,"memory.used_bytes":%d,"memory.free_bytes":%d,"cpu.utilization":%.4f,"network.bytes_sent":%d}`,
+			svc, reqs, memUsed, 4_000_000_000-memUsed, cpu, reqs*512)
+	}
+
+	// ------------------------------------------------------------------
+	// Attribute key deltas — one set per service/signal, included once.
+	// ------------------------------------------------------------------
+	nowNS := now.UnixNano()
+
+	spanAttrKeys := func(svc string) []store.AttrKeyDelta {
+		return []store.AttrKeyDelta{
+			{SignalType: "span", ServiceName: svc, Key: "meta.signal_type", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "meta.span_kind", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "meta.dataset", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "http.request.method", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "http.route", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "http.response.status_code", ValueType: "int", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "rpc.service", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "rpc.method", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "db.system", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "db.statement", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "span", ServiceName: svc, Key: "component", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+		}
+	}
+	logAttrKeys := func(svc string) []store.AttrKeyDelta {
+		return []store.AttrKeyDelta{
+			{SignalType: "log", ServiceName: svc, Key: "meta.signal_type", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "log", ServiceName: svc, Key: "meta.dataset", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "log", ServiceName: svc, Key: "component", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+		}
+	}
+	metricAttrKeys := func(svc string) []store.AttrKeyDelta {
+		return []store.AttrKeyDelta{
+			{SignalType: "metric", ServiceName: svc, Key: "meta.dataset", ValueType: "str", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "metric", ServiceName: svc, Key: "requests.total", ValueType: "int", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "metric", ServiceName: svc, Key: "memory.used_bytes", ValueType: "int", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "metric", ServiceName: svc, Key: "memory.free_bytes", ValueType: "int", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "metric", ServiceName: svc, Key: "cpu.utilization", ValueType: "flt", Count: 1, LastSeenNS: nowNS},
+			{SignalType: "metric", ServiceName: svc, Key: "network.bytes_sent", ValueType: "int", Count: 1, LastSeenNS: nowNS},
+		}
+	}
+
+	// Emit resources, scopes, and attr key catalog in one batch.
+	// WriteBatch skips attr-only batches, so we piggyback on resources.
+	var seedAttrKeys []store.AttrKeyDelta
+	for _, svc := range serviceNames {
+		seedAttrKeys = append(seedAttrKeys, spanAttrKeys(svc)...)
+		seedAttrKeys = append(seedAttrKeys, logAttrKeys(svc)...)
+		seedAttrKeys = append(seedAttrKeys, metricAttrKeys(svc)...)
+	}
+	if err := st.WriteBatch(ctx, store.Batch{
+		Resources: resources,
+		Scopes:    scopes,
+		AttrKeys:  seedAttrKeys,
+	}); err != nil {
+		log.Fatalf("seed resources/scopes/attrs: %v", err)
+	}
+
+	// ------------------------------------------------------------------
+	// Flush helper
+	// ------------------------------------------------------------------
+	batch := store.Batch{}
+	batch.Events = make([]store.Event, 0, *batchSz)
+	batch.MetricEvents = make([]store.MetricEvent, 0, *batchSz)
+
+	flushEvents := func() {
+		if len(batch.Events) == 0 {
+			return
+		}
+		if err := st.WriteBatch(ctx, batch); err != nil {
+			log.Fatalf("WriteBatch (events): %v", err)
+		}
+		batch.Events = batch.Events[:0]
+	}
+	flushMetrics := func() {
+		if len(batch.MetricEvents) == 0 {
+			return
+		}
+		if err := st.WriteBatch(ctx, batch); err != nil {
+			log.Fatalf("WriteBatch (metrics): %v", err)
+		}
+		batch.MetricEvents = batch.MetricEvents[:0]
+	}
+
+	progress := func(done, total int, phase string, start time.Time) {
+		pct := 100 * done / total
+		elapsed := time.Since(start).Round(time.Second)
+		rate := float64(done) / time.Since(start).Seconds()
+		eta := time.Duration(float64(total-done)/rate) * time.Second
+		log.Printf("%s: %d/%d (%d%%)  elapsed=%s  rate=%.0f/s  eta=%s",
+			phase, done, total, pct, elapsed, rate, eta.Round(time.Second))
+	}
+
+	wallStart := time.Now()
+
+	// ==================================================================
+	// Phase 1: Spans
+	// ==================================================================
+	log.Printf("phase 1/3: generating %d spans...", numSpans)
+	phaseStart := time.Now()
+	spansWritten := 0
+	const progressEvery = 250_000
+
+	for spansWritten < numSpans {
+		// Trace size: 1–20 spans per trace (geometric-ish)
+		traceSize := 1 + rng.IntN(4) + rng.IntN(4) + rng.IntN(4) + rng.IntN(4) + rng.IntN(4)
+		if spansWritten+traceSize > numSpans {
+			traceSize = numSpans - spansWritten
+		}
+
+		traceID := newTraceID()
+		rootTimeNS := randTimeNS()
+
+		// Root span
+		root := pick()
+		rootSpanID := newSpanID()
+		rootDur := int64(1+rng.IntN(5000)) * int64(time.Millisecond)
+		rootEnd := rootTimeNS + rootDur
+
+		var rootStatus int32
+		switch rng.IntN(20) {
+		case 0, 1: // 10% error
+			rootStatus = 2
+		default: // 90% OK/UNSET
+			rootStatus = 1
+		}
+
+		method := httpMethods[rng.IntN(len(httpMethods))]
+		route := httpRoutes[rng.IntN(len(httpRoutes))]
+		httpCode := 200
+		if rootStatus == 2 {
+			httpCode = 500
+		} else if rng.IntN(10) == 0 {
+			httpCode = 400
+		}
+
+		batch.Events = append(batch.Events, store.Event{
+			TimeNS:        rootTimeNS,
+			EndTimeNS:     i64p(rootEnd),
+			ResourceID:    root.resourceID,
+			ScopeID:       root.scopeID,
+			ServiceName:   root.serviceName,
+			Name:          method + " " + route,
+			TraceID:       traceID,
+			SpanID:        rootSpanID,
+			StatusCode:    i32p(rootStatus),
+			Flags:         u32p(1),
+			AttributesJSON: httpSpanAttrs(root.serviceName, "SERVER", method, route, httpCode),
+		})
+
+		// Child spans
+		for range traceSize - 1 {
+			child := pick()
+			childSpanID := newSpanID()
+			childOffset := rng.Int64N(rootDur / 2)
+			childTimeNS := rootTimeNS + childOffset
+			childDur := int64(1+rng.IntN(500)) * int64(time.Millisecond)
+			if childTimeNS+childDur > rootEnd {
+				childDur = rootEnd - childTimeNS
+				if childDur < int64(time.Millisecond) {
+					childDur = int64(time.Millisecond)
+				}
+			}
+			childEnd := childTimeNS + childDur
+
+			var childAttrs string
+			var childName string
+			switch rng.IntN(3) {
+			case 0: // RPC call
+				rpcSvc := rpcServices[rng.IntN(len(rpcServices))]
+				rpcMethod := rpcMethods[rng.IntN(len(rpcMethods))]
+				childName = rpcSvc + "/" + rpcMethod
+				childAttrs = rpcSpanAttrs(child.serviceName, "CLIENT", rpcSvc, rpcMethod)
+			case 1: // DB call
+				dbSys := dbSystems[rng.IntN(len(dbSystems))]
+				stmt := dbStatements[rng.IntN(len(dbStatements))]
+				childName = dbSys + ".query"
+				childAttrs = dbSpanAttrs(child.serviceName, dbSys, stmt)
+			default: // Internal
+				component := "middleware"
+				if rng.IntN(3) == 0 {
+					component = "cache"
+				}
+				childName = component + ".process"
+				childAttrs = internalSpanAttrs(child.serviceName, component)
+			}
+
+			var childStatus int32
+			if rootStatus == 2 && rng.IntN(3) == 0 {
+				childStatus = 2
+			} else {
+				childStatus = 1
+			}
+
+			batch.Events = append(batch.Events, store.Event{
+				TimeNS:         childTimeNS,
+				EndTimeNS:      i64p(childEnd),
+				ResourceID:     child.resourceID,
+				ScopeID:        child.scopeID,
+				ServiceName:    child.serviceName,
+				Name:           childName,
+				TraceID:        traceID,
+				SpanID:         childSpanID,
+				ParentSpanID:   rootSpanID,
+				StatusCode:     i32p(childStatus),
+				Flags:          u32p(1),
+				AttributesJSON: childAttrs,
+			})
+		}
+
+		prev := spansWritten
+		spansWritten += traceSize
+
+		if len(batch.Events) >= *batchSz {
+			flushEvents()
+		}
+		if spansWritten/progressEvery > prev/progressEvery || spansWritten >= numSpans {
+			progress(spansWritten, numSpans, "spans", phaseStart)
+		}
+	}
+	flushEvents()
+	log.Printf("phase 1/3 done: %d spans in %s", spansWritten, time.Since(phaseStart).Round(time.Second))
+
+	// ==================================================================
+	// Phase 2: Logs
+	// ==================================================================
+	log.Printf("phase 2/3: generating %d logs...", numLogs)
+	phaseStart = time.Now()
+	logsWritten := 0
+
+	for logsWritten < numLogs {
+		rs := pick()
+		sevIdx := rng.IntN(len(severityNums))
+		sevNum := severityNums[sevIdx]
+		sevText := severityTexts[sevIdx]
+		body := logBodies[rng.IntN(len(logBodies))]
+		component := "handler"
+		switch rng.IntN(4) {
+		case 1:
+			component = "middleware"
+		case 2:
+			component = "worker"
+		case 3:
+			component = "scheduler"
+		}
+
+		tNS := randTimeNS()
+		obsTNS := tNS + int64(rng.IntN(1000))*int64(time.Microsecond)
+
+		batch.Events = append(batch.Events, store.Event{
+			TimeNS:         tNS,
+			ResourceID:     rs.resourceID,
+			ScopeID:        rs.scopeID,
+			ServiceName:    rs.serviceName,
+			Name:           sevText + ": " + body,
+			SeverityNumber: i32p(sevNum),
+			SeverityText:   sevText,
+			Body:           body,
+			ObservedTimeNS: i64p(obsTNS),
+			AttributesJSON: logEventAttrs(rs.serviceName, component),
+		})
+
+		logsWritten++
+		if len(batch.Events) >= *batchSz {
+			flushEvents()
+		}
+		if logsWritten%progressEvery == 0 || logsWritten >= numLogs {
+			progress(logsWritten, numLogs, "logs", phaseStart)
+		}
+	}
+	flushEvents()
+	log.Printf("phase 2/3 done: %d logs in %s", logsWritten, time.Since(phaseStart).Round(time.Second))
+
+	// ==================================================================
+	// Phase 3: Metrics
+	// ==================================================================
+	log.Printf("phase 3/3: generating %d metric events...", numMetrics)
+	phaseStart = time.Now()
+	metricsWritten := 0
+
+	for metricsWritten < numMetrics {
+		rs := pick()
+		tNS := randTimeNS()
+		reqs := int64(rng.IntN(10_000))
+		memUsed := int64(256_000_000 + rng.IntN(3_744_000_000))
+		cpu := float64(rng.IntN(100)) / 100.0
+
+		batch.MetricEvents = append(batch.MetricEvents, store.MetricEvent{
+			TimeNS:         tNS,
+			ResourceID:     rs.resourceID,
+			ScopeID:        rs.scopeID,
+			ServiceName:    rs.serviceName,
+			AttributesJSON: metricEventAttrs(rs.serviceName, reqs, memUsed, cpu),
+		})
+
+		metricsWritten++
+		if len(batch.MetricEvents) >= *batchSz {
+			flushMetrics()
+		}
+		if metricsWritten%progressEvery == 0 || metricsWritten >= numMetrics {
+			progress(metricsWritten, numMetrics, "metrics", phaseStart)
+		}
+	}
+	flushMetrics()
+	log.Printf("phase 3/3 done: %d metrics in %s", metricsWritten, time.Since(phaseStart).Round(time.Second))
+
+	// ==================================================================
+	// Rebuild FTS index in one pass (much faster than per-row triggers).
+	// ==================================================================
+	log.Println("rebuilding FTS index...")
+	ftsStart := time.Now()
+	if _, err := wrDB.ExecContext(ctx, "INSERT INTO events_fts(events_fts) VALUES ('rebuild')"); err != nil {
+		log.Fatalf("rebuild FTS: %v", err)
+	}
+	log.Printf("FTS rebuild done: %s", time.Since(ftsStart).Round(time.Second))
+
+	// Restore FTS triggers so the DB works normally after load.
+	for _, trigSQL := range []string{
+		`CREATE TRIGGER IF NOT EXISTS events_ai AFTER INSERT ON events BEGIN
+			INSERT INTO events_fts(rowid, body, name, service_name)
+			VALUES (NEW.event_id, NEW.body, NEW.name, NEW.service_name); END`,
+		`CREATE TRIGGER IF NOT EXISTS events_ad AFTER DELETE ON events BEGIN
+			INSERT INTO events_fts(events_fts, rowid, body, name, service_name)
+			VALUES ('delete', OLD.event_id, OLD.body, OLD.name, OLD.service_name); END`,
+	} {
+		if _, err := wrDB.ExecContext(ctx, trigSQL); err != nil {
+			log.Fatalf("restore FTS trigger: %v", err)
+		}
+	}
+
+	// Checkpoint and truncate WAL so the .db file reflects all committed
+	// pages and the reported size is accurate.
+	if _, err := wrDB.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		log.Printf("WAL checkpoint: %v", err)
+	}
+
+	// Restore normal sync mode so the DB is safe for subsequent use.
+	if _, err := wrDB.ExecContext(ctx, "PRAGMA synchronous = NORMAL"); err != nil {
+		log.Printf("restore synchronous: %v", err)
+	}
+
+	// ==================================================================
+	// Final stats
+	// ==================================================================
+	fi, _ := os.Stat(*dbPath)
+	totalSize := int64(0)
+	if fi != nil {
+		totalSize = fi.Size()
+	}
+
+	log.Printf("loadgen-bulk complete!")
+	log.Printf("  elapsed:    %s", time.Since(wallStart).Round(time.Second))
+	log.Printf("  spans:      %d", spansWritten)
+	log.Printf("  logs:       %d", logsWritten)
+	log.Printf("  metrics:    %d", metricsWritten)
+	log.Printf("  total:      %d", spansWritten+logsWritten+metricsWritten)
+	log.Printf("  db path:    %s", *dbPath)
+	log.Printf("  db size:    %.1f MB (%.2f GB)", float64(totalSize)/(1<<20), float64(totalSize)/(1<<30))
+}

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,76 @@
+# Query Performance Benchmark
+
+Baseline timings for a 10 million event SQLite database, covering the main
+query shapes the UI and API emit. Run on a MacBook (Apple Silicon, NVMe SSD,
+`modernc.org/sqlite` pure-Go driver, WAL mode).
+
+## Dataset
+
+| Signal | Rows | Ratio |
+|--------|------|-------|
+| Spans  | 6,000,000 | 60% |
+| Logs   | 1,000,000 | 10% |
+| Metrics | 3,000,000 | 30% |
+| **Total** | **10,000,000** | |
+
+- **DB size on disk:** 4.42 GB (post-checkpoint, WAL truncated)
+- **Schema:** v3 — `events` (spans+logs) + `metric_events` (folded Honeycomb-style)
+- **Services:** 8 × 2 instances = 16 resources, timestamps spread over 24 h
+- **Generation time:** 18m31s with `cmd/loadgen-bulk`
+
+## Reproduction
+
+### 1. Generate the test database
+
+```bash
+# Creates ./waggle-test.db (~4.5 GB, takes ~20 min)
+go tool task loadgen-bulk -- --db ./waggle-test.db --total 10000000
+```
+
+Use `--seed N` for a reproducible dataset, otherwise the seed is time-based.
+Full flag reference: `go run ./cmd/loadgen-bulk --help`.
+
+### 2. Run the benchmark
+
+```bash
+# 3 runs per query, reports min/median/max
+go tool task bench-queries -- --db ./waggle-test.db --runs 3
+```
+
+## Results (3-run median, April 2026)
+
+All timings are the median of 3 consecutive runs against a warm OS page cache.
+`Rows` is the number of rows returned by the query.
+
+| # | Query | Rows | Min | Median | Max |
+|---|-------|------|-----|--------|-----|
+| 1 | LIST services (span count + error rate per service) | 8 | 9.148s | 9.184s | 9.207s |
+| 2 | LIST traces (root spans + span\_count correlated subquery, LIMIT 50) | 50 | 1ms | 2ms | 3ms |
+| 3 | COUNT(\*) all spans | 1 | 506ms | 526ms | 547ms |
+| 4 | COUNT(\*) all logs | 1 | 75ms | 75ms | 84ms |
+| 5 | COUNT(\*) all metric events | 1 | 3ms | 4ms | 26ms |
+| 6 | COUNT(\*) spans GROUP BY service\_name | 8 | 8.886s | 8.947s | 9.158s |
+| 7 | COUNT(\*) spans GROUP BY http\_route | 24 | 10.006s | 10.14s | 10.144s |
+| 8 | COUNT(\*) spans GROUP BY span\_kind | 3 | 12.107s | 12.171s | 12.184s |
+| 9 | Error rate per service (status\_code=2) | 8 | 9.055s | 9.073s | 9.165s |
+| 10 | P50/P95/P99 duration\_ns by service (percentile UDF) | 8 | 11.942s | 12.022s | 12.083s |
+| 11 | COUNT(\*) spans bucketed by 1h over full window | 25 | 2.993s | 3.011s | 3.093s |
+| 12 | COUNT(\*) spans bucketed 1h + GROUP BY service (multi-series) | 200 | 12.003s | 12.054s | 12.296s |
+| 13 | P95 duration\_ns bucketed 1h (percentile time-series) | 25 | 9.357s | 9.424s | 9.543s |
+| 14 | Raw span rows LIMIT 500 ORDER BY time DESC | 500 | 1ms | 1ms | 2ms |
+| 15 | COUNT(\*) spans filtered by service + quarter-window time range | 1 | 37ms | 38ms | 42ms |
+| 16 | COUNT(\*) spans WHERE http\_route = '/users' | 1 | 9.456s | 9.533s | 9.649s |
+| 17 | GET single trace (all spans for one trace\_id) | 8 | <1ms | <1ms | <1ms |
+| 18 | COUNT(\*) logs GROUP BY severity\_text | 4 | 2.559s | 2.563s | 2.582s |
+| 19 | Raw log rows LIMIT 500 ORDER BY time DESC | 500 | 1ms | 1ms | 2ms |
+| 20 | FTS log search: body MATCH 'payment' | 100 | 370ms | 371ms | 372ms |
+| 21 | COUNT(\*) metric\_events GROUP BY service\_name | 8 | 250ms | 253ms | 254ms |
+| 22 | MAX(requests.total) metric GROUP BY service\_name (json\_extract) | 8 | 11.987s | 12.021s | 12.108s |
+| 23 | AVG(cpu.utilization) metric bucketed 1h (json\_extract) | 25 | 13.039s | 13.061s | 13.099s |
+| 24 | COUNT(\*) spans WHERE json\_extract(attributes, '$.component') = 'middleware' | 1 | 9.511s | 9.686s | 9.713s |
+| 25 | COUNT(DISTINCT trace\_id) — trace cardinality | 1 | 9.496s | 9.635s | 9.752s |
+| 26 | COUNT(\*) root spans only (partial index on parent\_span\_id IS NULL) | 1 | 5.432s | 5.436s | 5.455s |
+| 27 | Top-100 slowest spans (ORDER BY duration\_ns DESC) | 100 | 6.093s | 6.103s | 6.113s |
+| 28 | COUNT(\*) + AVG duration of ERROR spans (status\_code=2) by service | 8 | 5.563s | 5.568s | 5.597s |
+| 29 | LIST attribute\_keys for spans (field catalog) | 88 | <1ms | <1ms | <1ms |
+| 30 | COUNT(\*) entire events table (all signals) | 1 | 125ms | 125ms | 125ms |


### PR DESCRIPTION
## Summary

- **cmd/loadgen-bulk** — direct-to-SQLite bulk loader; generates 10M events (60% spans / 10% logs / 30% metrics) in ~20 min at ~4.5 GB without touching the OTLP/HTTP path
- **cmd/bench-queries** — 30-query timing battery covering every major API shape (service list, trace list, single trace, raw rows, GROUP BY, time-bucketed aggregations, percentile UDF, FTS, metric json_extract)
- **docs/benchmark.md** — dataset spec, reproduction steps, and April 2026 baseline timings (3-run median on Apple Silicon)
- **Taskfile.yml** — `loadgen-bulk` and `bench-queries` tasks

No application code changed.