### PR TITLE
feat(ui): manual Run button — filter edits no longer auto-execute

### DIFF
--- a/ui/src/features/query/DefinePanel.tsx
+++ b/ui/src/features/query/DefinePanel.tsx
@@ -95,7 +95,8 @@ export function DefinePanel({ dataset, search, onChange, onDatasetChange, onRun,
         <button
           type="button"
           onClick={onRun}
-          className="absolute top-2 right-2 flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-white z-10"
+          disabled={isRunning}
+          className="absolute top-2 right-2 flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium text-white z-10 disabled:opacity-60 disabled:cursor-not-allowed"
           style={{ background: "var(--color-accent)" }}
         >
           {isRunning ? <RotateCw className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}

--- a/ui/src/features/query/EventsTable.tsx
+++ b/ui/src/features/query/EventsTable.tsx
@@ -23,7 +23,8 @@ export interface SelectedRow {
 
 interface Props {
   dataset: Dataset;
-  search: QuerySearch;
+  querySearch: QuerySearch;
+  runCount: number;
   /** Reports the scroll container's vertical offset on every scroll event so
    *  the page can collapse the query/chart header once the user drills in. */
   onScrollY?: (y: number) => void;
@@ -39,18 +40,19 @@ interface Props {
  * dataset + WHERE + time range. Backed by the same /api/query endpoint the
  * chart uses; empty SELECT switches that endpoint into raw-rows mode.
  */
-export function EventsTable({ dataset, search, onScrollY, selected, onSelect }: Props) {
+export function EventsTable({ dataset, querySearch, runCount, onScrollY, selected, onSelect }: Props) {
   const result = useQuery({
     queryKey: [
       "events",
       dataset,
-      search.where,
-      search.range,
-      search.from,
-      search.to,
+      querySearch.where,
+      querySearch.range,
+      querySearch.from,
+      querySearch.to,
+      runCount,
     ],
     queryFn: ({ signal }) => {
-      const resolved = resolveSearchRange(search);
+      const resolved = resolveSearchRange(querySearch);
       return runQuery(
         {
           dataset,
@@ -59,13 +61,13 @@ export function EventsTable({ dataset, search, onScrollY, selected, onSelect }: 
             to: new Date(resolved.toMs).toISOString(),
           },
           select: [], // raw-rows mode
-          where: search.where,
+          where: querySearch.where,
           limit: 500,
         },
         signal,
       );
     },
-    refetchInterval: refreshIntervalMs(search.refresh),
+    refetchInterval: refreshIntervalMs(querySearch.refresh),
   });
 
   if (result.isPending) return <Centered>Loading…</Centered>;

--- a/ui/src/features/query/OverviewTab.tsx
+++ b/ui/src/features/query/OverviewTab.tsx
@@ -5,7 +5,8 @@ import { serviceColor } from "../../lib/colors";
 
 interface Props {
   dataset: Dataset;
-  search: QuerySearch;
+  querySearch: QuerySearch;
+  runCount: number;
 }
 
 /**
@@ -15,11 +16,11 @@ interface Props {
  * request — same SELECT/WHERE as the chart but with bucket_ms omitted, so
  * each group tuple collapses to a single row.
  */
-export function OverviewTab({ dataset, search }: Props) {
+export function OverviewTab({ dataset, querySearch, runCount }: Props) {
   const overview = useQuery({
-    queryKey: ["overview", dataset, search],
+    queryKey: ["overview", dataset, querySearch, runCount],
     queryFn: ({ signal }) =>
-      runQuery(buildOverviewQuery(dataset, search), signal),
+      runQuery(buildOverviewQuery(dataset, querySearch), signal),
     refetchInterval: 10_000,
   });
 

--- a/ui/src/features/query/ResultTabs.tsx
+++ b/ui/src/features/query/ResultTabs.tsx
@@ -8,7 +8,14 @@ type TabID = "overview" | "traces" | "explore";
 
 interface Props {
   dataset: Dataset;
+  /** URL-driven search — used only for tab routing state, never for queries. */
   search: QuerySearch;
+  /** The last-committed query params (set when the user clicks Run). All
+   *  tab queries execute against this, not the live edit state. */
+  querySearch: QuerySearch;
+  /** Increments on every Run click, forcing a refetch even when params
+   *  are unchanged since the last run. */
+  runCount: number;
   onTabChange: (tab: TabID) => void;
   /** Optional slot for a logs-only FTS search input rendered next to tabs. */
   rightSlot?: React.ReactNode;
@@ -41,6 +48,8 @@ const TABS: Tab[] = [
 export function ResultTabs({
   dataset,
   search,
+  querySearch,
+  runCount,
   onTabChange,
   rightSlot,
   onExploreScrollY,
@@ -95,12 +104,13 @@ export function ResultTabs({
         {rightSlot ? <div className="py-1">{rightSlot}</div> : null}
       </div>
       <div className="flex-1 overflow-hidden">
-        {active === "overview" && <OverviewTab dataset={dataset} search={search} />}
-        {active === "traces" && <TracesTab search={search} />}
+        {active === "overview" && <OverviewTab dataset={dataset} querySearch={querySearch} runCount={runCount} />}
+        {active === "traces" && <TracesTab querySearch={querySearch} runCount={runCount} />}
         {active === "explore" && (
           <EventsTable
             dataset={dataset}
-            search={search}
+            querySearch={querySearch}
+            runCount={runCount}
             onScrollY={onExploreScrollY}
             selected={selectedRow ?? null}
             onSelect={onSelectRow}

--- a/ui/src/features/query/TracesTab.tsx
+++ b/ui/src/features/query/TracesTab.tsx
@@ -7,7 +7,8 @@ import { formatDuration, formatRelativeTimestamp } from "../../lib/format";
 import { CopyButton } from "../../components/ui/CopyButton";
 
 interface Props {
-  search: QuerySearch;
+  querySearch: QuerySearch;
+  runCount: number;
 }
 
 /**
@@ -16,11 +17,11 @@ interface Props {
  * Each row is one trace (by virtue of being its root span) and links into
  * the full waterfall view.
  */
-export function TracesTab({ search }: Props) {
+export function TracesTab({ querySearch, runCount }: Props) {
   const result = useQuery({
-    queryKey: ["traces-tab", search],
+    queryKey: ["traces-tab", querySearch, runCount],
     queryFn: ({ signal }) => {
-      const resolved = resolveSearchRange(search);
+      const resolved = resolveSearchRange(querySearch);
       return runQuery(
         {
           dataset: "spans",
@@ -30,7 +31,7 @@ export function TracesTab({ search }: Props) {
           },
           select: [], // raw rows
           where: [
-            ...search.where,
+            ...querySearch.where,
             { field: "is_root", op: "=", value: true },
           ],
           order_by: [{ field: "duration_ns", dir: "desc" }],

--- a/ui/src/routes/EventsPage.tsx
+++ b/ui/src/routes/EventsPage.tsx
@@ -128,16 +128,19 @@ export function EventsPage() {
 
   useRefreshPersistence(search, setSearch);
 
+  // committedSearch is the query that was last *run*. It only advances when
+  // the user clicks Run — filter edits alone don't trigger a fetch.
+  const [committedSearch, setCommittedSearch] = useState<QuerySearch>(search);
+  // runCount is included in the queryKey so clicking Run with unchanged
+  // params still forces a fresh fetch (same key otherwise → cache hit).
+  const [runCount, setRunCount] = useState(0);
+
   const chart = useQuery({
-    queryKey: ["query", search.dataset, search],
+    queryKey: ["query", committedSearch.dataset, committedSearch, runCount],
     queryFn: ({ signal }) =>
-      runQuery(buildCountQuery(search.dataset, search), signal),
-    refetchInterval: refreshIntervalMs(search.refresh),
-    // For metrics the default COUNT-of-metric-events isn't informative on
-    // its own — the user needs to pick a specific metric field (e.g.
-    // MAX(requests.total)) before the chart means anything. Disable the
-    // fetch until they have.
-    enabled: search.dataset !== "metrics" || hasMetricField(search),
+      runQuery(buildCountQuery(committedSearch.dataset, committedSearch), signal),
+    refetchInterval: refreshIntervalMs(committedSearch.refresh),
+    enabled: committedSearch.dataset !== "metrics" || hasMetricField(committedSearch),
   });
 
   const resolved = resolveSearchRange(search);
@@ -176,7 +179,7 @@ export function EventsPage() {
             search={search}
             onChange={setSearch}
             onDatasetChange={changeDataset}
-            onRun={() => chart.refetch()}
+            onRun={() => { setCommittedSearch(search); setRunCount((c) => c + 1); }}
             isRunning={chart.isFetching}
           />
         </Accordion>
@@ -212,6 +215,8 @@ export function EventsPage() {
           <ResultTabs
             dataset={search.dataset}
             search={search}
+            querySearch={committedSearch}
+            runCount={runCount}
             onTabChange={(tab) => setSearch({ ...search, tab })}
             onExploreScrollY={handleExploreScrollY}
             selectedRow={detailPaneEligible ? selectedRow : null}


### PR DESCRIPTION
## Summary

- Filter edits (SELECT, WHERE, GROUP BY, time range, etc.) no longer immediately fire queries — with 9–12 s queries at 10 M event scale this made the editor unusable
- Run button is the sole trigger; clicking it commits the current draft and fires one fetch across the chart + all tabs simultaneously
- Run button shows a spinner and is disabled while a query is in flight, preventing double-submission
- Auto-refresh (`refetchInterval`) still works as before against the last-committed params

## How it works

`EventsPage` now maintains two search states:
- **`search`** (URL / draft) — updated instantly on every filter edit, drives the editor UI
- **`committedSearch`** — only advances when Run is clicked; all `queryKey` arrays use this so React Query never auto-fetches on edits

A `runCount` integer in every `queryKey` ensures clicking Run with unchanged params still produces a fresh fetch (same key otherwise = cache hit).

`ResultTabs`, `OverviewTab`, `TracesTab`, and `EventsTable` all receive `querySearch={committedSearch}` + `runCount` instead of the live `search`.