### PR TITLE
feat: --tee to mirror log records to a terminal or file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,49 @@ explore chrome.
 Every URL serialises the full query state (filters, group-by, aggregates,
 time range, granularity) so shared links reproduce the view.
 
+### Tee logs to a terminal or file
+
+`--tee` mirrors incoming OTLP log records to a second output in a
+human-readable format — zerolog-style `console` by default, plus
+`logfmt` and `json`. It's a pure passthrough; SQLite is still
+authoritative and the UI is unchanged. Handy for two common shapes:
+
+**Watch logs in a terminal while you explore traces + metrics in the
+browser.** When a trace in the UI points at a service, you can often
+just glance at the tailing terminal to see *that* service's logs scroll
+past, without context-switching between panes.
+
+```sh
+# Colourised live feed, filtered to two services, WARN+ only
+waggle --tee - \
+  --tee-service api-gateway,payments \
+  --tee-severity warn
+```
+
+Colour is `auto` by default — on when stdout is a TTY and the format
+is `console`, off otherwise. Use `--tee-color always` if you're piping
+to `less -R` / `ccze`, or `never` to strip escapes unconditionally.
+
+**Save logs to disk for later investigation.** For long-running local
+sessions, or when you need a durable copy the SQLite retention sweep
+(`--retention 24h` by default) won't eventually drop. `logfmt` is
+grep/awk-friendly, `json` is jq-friendly.
+
+```sh
+# Rolling log file, logfmt (grep/awk-friendly)
+waggle --tee logs/waggle.logfmt --tee-format logfmt
+
+# NDJSON — one record per line, point jq at it
+waggle --tee logs/waggle.ndjson --tee-format json
+
+# Paginate a live feed through less with ANSI-aware paging
+waggle --tee - --tee-color always | less -R
+```
+
+Only log records are tee'd; spans and metrics go to SQLite as normal.
+The sink is best-effort — a write failure is logged once and the
+ingest path keeps going.
+
 ### Query model
 
 Following Honeycomb's *Metrics 2.0* mapping, a metric datapoint is an
@@ -197,6 +240,11 @@ All flags have matching environment variables. Flags take precedence.
 | `--retention` | `WAGGLE_RETENTION` | `24h` | Drop data older than this (Go duration; `0` disables). |
 | `--log-level` | `WAGGLE_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error`. |
 | `--dev` | — | `false` | Dev mode: do not serve embedded UI, do not open browser. |
+| `--tee` | `WAGGLE_TEE` | — | Mirror incoming log records to this path (`-` = stdout). See the Tee section above. |
+| `--tee-service` | `WAGGLE_TEE_SERVICE` | — | Comma-separated `service.name` allow-list. Omit for all services. |
+| `--tee-severity` | `WAGGLE_TEE_SEVERITY` | — | Severity floor: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. |
+| `--tee-format` | `WAGGLE_TEE_FORMAT` | `console` | `console` (zerolog-style), `logfmt`, or `json` (NDJSON). |
+| `--tee-color` | `WAGGLE_TEE_COLOR` | `auto` | ANSI colour for `console` format: `auto` (TTY-detect), `always`, `never`. |
 
 When `--ingest-addr` and `--ui-addr` differ, waggle binds two HTTP listeners;
 otherwise a single listener serves everything on `--addr`.

--- a/cmd/waggle/main.go
+++ b/cmd/waggle/main.go
@@ -41,7 +41,22 @@ func main() {
 	writer := ingest.NewWriter(st, log, ingest.WriterConfig{})
 	writer.Start(ctx)
 
-	handler := ingest.NewHandler(writer, log)
+	tee, err := ingest.NewTee(ingest.TeeConfig{
+		Path:     cfg.TeePath,
+		Services: cfg.TeeServices,
+		MinSev:   cfg.TeeMinSev,
+		Format:   cfg.TeeFormat,
+		Color:    cfg.TeeColor,
+	})
+	if err != nil {
+		log.Error("failed to open tee", "err", err)
+		os.Exit(1)
+	}
+	if tee != nil {
+		log.Info("tee enabled", "path", cfg.TeePath, "services", cfg.TeeServices, "min_severity", cfg.TeeMinSev, "format", cfg.TeeFormat)
+	}
+
+	handler := ingest.NewHandler(writer, log).WithTee(tee)
 	router := api.NewRouter(st, log)
 	srv := server.New(cfg, log, st, handler, router)
 
@@ -70,6 +85,9 @@ func main() {
 	}
 	if err := writer.Stop(shutdownCtx); err != nil {
 		log.Error("writer stop", "err", err)
+	}
+	if err := tee.Close(); err != nil {
+		log.Warn("tee close", "err", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,18 +5,30 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
 type Config struct {
-	DBPath         string
-	Addr           string
-	IngestAddr     string
-	UIAddr         string
-	NoOpenBrowser  bool
-	Retention      time.Duration
-	LogLevel       string
-	Dev            bool
+	DBPath        string
+	Addr          string
+	IngestAddr    string
+	UIAddr        string
+	NoOpenBrowser bool
+	Retention     time.Duration
+	LogLevel      string
+	Dev           bool
+
+	// Tee: mirror incoming log records to a file or stdout in one of
+	// several human-readable formats, so a dev can pipe them to `less`
+	// in a shell next to the UI. Tee is strictly a passthrough — what
+	// lands on the tee is a subset of what's stored, and the store is
+	// still authoritative.
+	TeePath     string   // path to mirror file, or "-" for stdout. Empty = disabled.
+	TeeServices []string // parsed from --tee-service (comma-separated). Empty = all services.
+	TeeMinSev   int32    // minimum severity_number (OTel); 0 = no floor.
+	TeeFormat   string   // "console" (default) | "logfmt" | "json"
+	TeeColor    string   // "auto" (default, TTY-detect) | "always" | "never"
 }
 
 func Load() (*Config, error) {
@@ -30,6 +42,12 @@ func Load() (*Config, error) {
 	retentionStr := flag.String("retention", envOr("WAGGLE_RETENTION", "24h"), "Drop data older than this")
 	flag.StringVar(&c.LogLevel, "log-level", envOr("WAGGLE_LOG_LEVEL", "info"), "slog level: debug, info, warn, error")
 	flag.BoolVar(&c.Dev, "dev", false, "Dev mode: do not serve embedded UI and do not open browser")
+
+	flag.StringVar(&c.TeePath, "tee", envOr("WAGGLE_TEE", ""), "Mirror log records to this path (use '-' for stdout)")
+	teeServicesRaw := flag.String("tee-service", envOr("WAGGLE_TEE_SERVICE", ""), "Comma-separated service.name list to tee (empty = all services)")
+	teeSeverity := flag.String("tee-severity", envOr("WAGGLE_TEE_SEVERITY", ""), "Floor severity to tee: trace|debug|info|warn|error|fatal")
+	flag.StringVar(&c.TeeFormat, "tee-format", envOr("WAGGLE_TEE_FORMAT", "console"), "Tee output format: console|logfmt|json")
+	flag.StringVar(&c.TeeColor, "tee-color", envOr("WAGGLE_TEE_COLOR", "auto"), "ANSI colour: auto|always|never (console format only)")
 
 	flag.Parse()
 
@@ -46,7 +64,51 @@ func Load() (*Config, error) {
 		c.UIAddr = c.Addr
 	}
 
+	for s := range strings.SplitSeq(*teeServicesRaw, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			c.TeeServices = append(c.TeeServices, s)
+		}
+	}
+	if *teeSeverity != "" {
+		n, err := parseTeeSeverity(*teeSeverity)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --tee-severity %q: %w", *teeSeverity, err)
+		}
+		c.TeeMinSev = n
+	}
+	switch c.TeeFormat {
+	case "console", "logfmt", "json":
+	default:
+		return nil, fmt.Errorf("invalid --tee-format %q (want: console, logfmt, json)", c.TeeFormat)
+	}
+	switch c.TeeColor {
+	case "auto", "always", "never":
+	default:
+		return nil, fmt.Errorf("invalid --tee-color %q (want: auto, always, never)", c.TeeColor)
+	}
+
 	return c, nil
+}
+
+// parseTeeSeverity maps a short level name to the OTel SeverityNumber
+// floor it implies. We use the start-of-band number (TRACE=1, DEBUG=5,
+// etc.) so `--tee-severity=warn` admits WARN (13) and everything above.
+func parseTeeSeverity(s string) (int32, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "trace":
+		return 1, nil
+	case "debug":
+		return 5, nil
+	case "info":
+		return 9, nil
+	case "warn", "warning":
+		return 13, nil
+	case "error", "err":
+		return 17, nil
+	case "fatal":
+		return 21, nil
+	}
+	return 0, fmt.Errorf("unknown level (want trace|debug|info|warn|error|fatal)")
 }
 
 func (c *Config) SplitListeners() bool {

--- a/internal/ingest/otlp_http.go
+++ b/internal/ingest/otlp_http.go
@@ -18,11 +18,19 @@ import (
 // Handler wires the OTLP ingest HTTP endpoints to the Writer.
 type Handler struct {
 	writer *Writer
+	tee    *Tee // optional log-mirror sink; nil = disabled
 	log    *slog.Logger
 }
 
 func NewHandler(w *Writer, log *slog.Logger) *Handler {
 	return &Handler{writer: w, log: log}
+}
+
+// WithTee attaches a log-mirror sink. Pass nil to keep tee disabled.
+// Chainable so the caller can write `NewHandler(...).WithTee(tee)`.
+func (h *Handler) WithTee(t *Tee) *Handler {
+	h.tee = t
+	return h
 }
 
 // Mount registers POST /v1/{traces,logs,metrics} on the given mux.
@@ -53,6 +61,10 @@ func (h *Handler) handleLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	batch := otlp.TransformResourceLogs(req.ResourceLogs)
+	// Tee *before* enqueue so the mirror reflects the same records that
+	// were accepted, even if enqueue later returns backpressure-513.
+	// Tee is a no-op when not configured.
+	h.tee.WriteBatch(batch)
 	if !h.writer.Enqueue(batch) {
 		h.writeBackpressure(w, r, "logs")
 		return

--- a/internal/ingest/tee.go
+++ b/internal/ingest/tee.go
@@ -1,0 +1,515 @@
+package ingest
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/danielloader/waggle/internal/store"
+)
+
+// TeeConfig controls log-mirror output. Zero value = disabled.
+type TeeConfig struct {
+	Path     string   // file path, "-" for stdout, empty for disabled
+	Services []string // allow-list of service.name; empty = all
+	MinSev   int32    // SeverityNumber floor (inclusive); 0 = no floor
+	Format   string   // "console" | "logfmt" | "json"
+	Color    string   // "auto" (default) | "always" | "never"
+}
+
+// Tee mirrors incoming log Events to an io.Writer in a human-readable
+// format so a user can `tail -f` / `less +F` them from a shell alongside
+// the Waggle UI. It is strictly a passthrough view of the ingest stream;
+// the Store is still authoritative, and Tee never blocks or errors out
+// the ingest path — write failures are logged once and the rest of the
+// batch continues.
+//
+// Not used on spans or metrics. Only log records (signal_type='log')
+// flow through here; the handler calls us from handleLogs only.
+type Tee struct {
+	cfg      TeeConfig
+	out      io.Writer
+	bw       *bufio.Writer
+	mu       sync.Mutex
+	closer   io.Closer
+	services map[string]struct{}
+	format   teeFormat
+	color    bool // ANSI colour enabled for console format
+	// warnedErr is sticky — we log a write error once and keep quiet
+	// afterwards so a broken pipe doesn't spam the server log.
+	warnedErr bool
+}
+
+type teeFormat int
+
+const (
+	teeConsole teeFormat = iota
+	teeLogfmt
+	teeJSON
+)
+
+// NewTee opens the configured sink. When cfg.Path is empty, NewTee
+// returns (nil, nil) — a nil *Tee is a no-op and callers should guard.
+func NewTee(cfg TeeConfig) (*Tee, error) {
+	if cfg.Path == "" {
+		return nil, nil
+	}
+	var (
+		w      io.Writer
+		closer io.Closer
+		isTTY  bool
+	)
+	if cfg.Path == "-" {
+		w = os.Stdout
+		isTTY = term.IsTerminal(int(os.Stdout.Fd()))
+	} else {
+		f, err := os.OpenFile(cfg.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return nil, fmt.Errorf("open tee %q: %w", cfg.Path, err)
+		}
+		w = f
+		closer = f
+	}
+	f := teeConsole
+	switch strings.ToLower(cfg.Format) {
+	case "", "console":
+		f = teeConsole
+	case "logfmt":
+		f = teeLogfmt
+	case "json":
+		f = teeJSON
+	default:
+		if closer != nil {
+			closer.Close()
+		}
+		return nil, fmt.Errorf("unknown tee format %q", cfg.Format)
+	}
+	color := false
+	if f == teeConsole {
+		switch strings.ToLower(cfg.Color) {
+		case "always":
+			color = true
+		case "never":
+			color = false
+		case "", "auto":
+			// auto: colour only when writing to a real terminal, and
+			// only for the console format. logfmt/json are machine-
+			// readable — no colour there.
+			color = isTTY
+		default:
+			if closer != nil {
+				closer.Close()
+			}
+			return nil, fmt.Errorf("unknown tee color %q (want auto|always|never)", cfg.Color)
+		}
+	}
+	t := &Tee{
+		cfg:    cfg,
+		out:    w,
+		bw:     bufio.NewWriter(w),
+		closer: closer,
+		format: f,
+		color:  color,
+	}
+	if len(cfg.Services) > 0 {
+		t.services = make(map[string]struct{}, len(cfg.Services))
+		for _, s := range cfg.Services {
+			t.services[s] = struct{}{}
+		}
+	}
+	return t, nil
+}
+
+// WriteBatch renders each log Event in the batch that passes the
+// service + severity filter to the sink, then flushes the buffer.
+// Safe to call from multiple goroutines.
+func (t *Tee) WriteBatch(b store.Batch) {
+	if t == nil || len(b.Events) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := range b.Events {
+		e := &b.Events[i]
+		if !t.passesFilter(e) {
+			continue
+		}
+		if err := t.writeOne(e); err != nil && !t.warnedErr {
+			// Don't take the ingest path down over a tee failure.
+			// Log once, then stay quiet.
+			fmt.Fprintf(os.Stderr, "waggle: tee write failed: %v\n", err)
+			t.warnedErr = true
+			return
+		}
+	}
+	if err := t.bw.Flush(); err != nil && !t.warnedErr {
+		fmt.Fprintf(os.Stderr, "waggle: tee flush failed: %v\n", err)
+		t.warnedErr = true
+	}
+}
+
+// Close flushes any buffered output and, for file-backed tees, closes
+// the underlying file. Idempotent. Safe to call even if NewTee returned
+// a nil *Tee.
+func (t *Tee) Close() error {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var firstErr error
+	if err := t.bw.Flush(); err != nil {
+		firstErr = err
+	}
+	if t.closer != nil {
+		if err := t.closer.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (t *Tee) passesFilter(e *store.Event) bool {
+	if t.services != nil {
+		if _, ok := t.services[e.ServiceName]; !ok {
+			return false
+		}
+	}
+	if t.cfg.MinSev > 0 {
+		if e.SeverityNumber == nil || *e.SeverityNumber < t.cfg.MinSev {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *Tee) writeOne(e *store.Event) error {
+	switch t.format {
+	case teeConsole:
+		return writeConsole(t.bw, e, t.color)
+	case teeLogfmt:
+		return writeLogfmt(t.bw, e)
+	case teeJSON:
+		return writeJSONLine(t.bw, e)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Formatters. All produce a single line terminated with '\n'.
+// ---------------------------------------------------------------------------
+
+func writeConsole(w io.Writer, e *store.Event, color bool) error {
+	// Wall-clock HH:MM:SS.mmm in the local timezone — matches the Tail
+	// UI's render so the two streams look identical side-by-side.
+	t := time.Unix(0, e.TimeNS).Local()
+	ts := fmt.Sprintf("%02d:%02d:%02d.%03d",
+		t.Hour(), t.Minute(), t.Second(), t.Nanosecond()/1_000_000)
+	num := severityNumOf(e)
+	sev := abbrevSeverity(e.SeverityText, num)
+	svc := e.ServiceName
+	body := e.Body
+	isError := num >= 17
+
+	// `time SEV service body key=value key=value`. Colourised to match
+	// the Tail UI palette: muted-grey timestamp, severity-coloured
+	// level pill, dim service name, bold-white body, cyan keys, red
+	// values for error fields on error-level rows.
+	var sb strings.Builder
+	writeColored(&sb, color, ansiTime, ts)
+	sb.WriteByte(' ')
+	writeColored(&sb, color, ansiSeverity(num)+";1", sev)
+	sb.WriteByte(' ')
+	if svc != "" {
+		writeColored(&sb, color, ansiService, svc)
+		sb.WriteByte(' ')
+	}
+	writeColored(&sb, color, ansiBody, body)
+	writeConsoleAttrs(&sb, e.AttributesJSON, color, isError)
+	sb.WriteByte('\n')
+	_, err := io.WriteString(w, sb.String())
+	return err
+}
+
+// writeConsoleAttrs is writeLogfmtAttrs with optional colour per segment.
+// When `color` is false it behaves identically. When true, keys get cyan,
+// values stay default, and on error-level rows `error`/`exception.*` field
+// values get bold-red — the same highlight the Tail UI applies.
+func writeConsoleAttrs(sb *strings.Builder, attrsJSON string, color, errorRow bool) {
+	if attrsJSON == "" || attrsJSON == "{}" {
+		return
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(attrsJSON), &raw); err != nil {
+		return
+	}
+	for k, v := range raw {
+		if strings.HasPrefix(k, "meta.") {
+			continue
+		}
+		sb.WriteByte(' ')
+		writeColored(sb, color, ansiKey, k+"=")
+		valStyle := ""
+		if color && errorRow && isErrorAttrKey(k) {
+			valStyle = ansiErrorValue
+		}
+		if valStyle != "" {
+			sb.WriteString(csiStart(valStyle))
+			writeLogfmtScalar(sb, v)
+			sb.WriteString(csiReset)
+		} else {
+			writeLogfmtScalar(sb, v)
+		}
+	}
+}
+
+// isErrorAttrKey mirrors the UI's ERROR_ATTR_KEYS set so the tee's
+// error-value highlight picks out the same attributes the Tail tab does.
+func isErrorAttrKey(k string) bool {
+	switch k {
+	case "error", "err",
+		"error.message", "error.type",
+		"exception.message", "exception.type", "exception.stacktrace":
+		return true
+	}
+	return false
+}
+
+// --- ANSI helpers ------------------------------------------------------
+
+const (
+	// CSI m codes. Semicolon-joined inside a single ESC[...m for
+	// combined attributes (e.g. "31;1" = red + bold).
+	ansiTime       = "90"    // bright black (grey)
+	ansiService    = "37;2"  // white, dim
+	ansiBody       = "1"     // bold (keeps default fg = white)
+	ansiKey        = "36"    // cyan
+	ansiErrorValue = "31;1"  // red, bold
+	csiReset       = "\x1b[0m"
+)
+
+func ansiSeverity(num int32) string {
+	switch {
+	case num >= 21:
+		return "31" // FATAL: red
+	case num >= 17:
+		return "31" // ERROR: red
+	case num >= 13:
+		return "33" // WARN: yellow
+	case num >= 9:
+		return "32" // INFO: green
+	case num >= 5:
+		return "34" // DEBUG: blue
+	case num > 0:
+		return "90" // TRACE: grey
+	}
+	return "90"
+}
+
+func csiStart(code string) string { return "\x1b[" + code + "m" }
+
+func writeColored(sb *strings.Builder, color bool, code, s string) {
+	if !color || code == "" {
+		sb.WriteString(s)
+		return
+	}
+	sb.WriteString(csiStart(code))
+	sb.WriteString(s)
+	sb.WriteString(csiReset)
+}
+
+func writeLogfmt(w io.Writer, e *store.Event) error {
+	t := time.Unix(0, e.TimeNS).UTC().Format("2006-01-02T15:04:05.000Z")
+	level := strings.ToLower(abbrevSeverityFull(e.SeverityText, severityNumOf(e)))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "time=%s level=%s", t, level)
+	if e.ServiceName != "" {
+		sb.WriteString(" service=")
+		writeLogfmtValue(&sb, e.ServiceName)
+	}
+	if e.Body != "" {
+		sb.WriteString(" msg=")
+		writeLogfmtValue(&sb, e.Body)
+	}
+	writeLogfmtAttrs(&sb, e.AttributesJSON)
+	sb.WriteByte('\n')
+	_, err := io.WriteString(w, sb.String())
+	return err
+}
+
+func writeJSONLine(w io.Writer, e *store.Event) error {
+	obj := make(map[string]any, 6)
+	obj["time"] = time.Unix(0, e.TimeNS).UTC().Format("2006-01-02T15:04:05.000000000Z")
+	obj["severity"] = abbrevSeverityFull(e.SeverityText, severityNumOf(e))
+	if e.ServiceName != "" {
+		obj["service"] = e.ServiceName
+	}
+	if e.Body != "" {
+		obj["body"] = e.Body
+	}
+	if e.AttributesJSON != "" && e.AttributesJSON != "{}" {
+		// Re-decode just to filter meta.* keys — callers asked for a
+		// clean record, not the storage-shape blob.
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(e.AttributesJSON), &raw); err == nil {
+			for k := range raw {
+				if strings.HasPrefix(k, "meta.") {
+					delete(raw, k)
+				}
+			}
+			if len(raw) > 0 {
+				obj["attrs"] = raw
+			}
+		}
+	}
+	enc := json.NewEncoder(w)
+	return enc.Encode(obj)
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func severityNumOf(e *store.Event) int32 {
+	if e.SeverityNumber == nil {
+		return 0
+	}
+	return *e.SeverityNumber
+}
+
+// abbrevSeverity returns the 3-letter short form used by the Tail UI
+// (TRC/DBG/INF/WRN/ERR/FTL). Falls back to the SeverityText if set,
+// then the band derived from SeverityNumber, then "---".
+func abbrevSeverity(text string, num int32) string {
+	full := abbrevSeverityFull(text, num)
+	switch full {
+	case "TRACE":
+		return "TRC"
+	case "DEBUG":
+		return "DBG"
+	case "INFO":
+		return "INF"
+	case "WARN":
+		return "WRN"
+	case "ERROR":
+		return "ERR"
+	case "FATAL":
+		return "FTL"
+	}
+	if len(full) >= 3 {
+		return strings.ToUpper(full[:3])
+	}
+	return "---"
+}
+
+func abbrevSeverityFull(text string, num int32) string {
+	if text != "" {
+		return strings.ToUpper(text)
+	}
+	switch {
+	case num >= 21:
+		return "FATAL"
+	case num >= 17:
+		return "ERROR"
+	case num >= 13:
+		return "WARN"
+	case num >= 9:
+		return "INFO"
+	case num >= 5:
+		return "DEBUG"
+	case num > 0:
+		return "TRACE"
+	}
+	return ""
+}
+
+// writeLogfmtAttrs renders an OTel attributes JSON blob as space-separated
+// `key=value` pairs, skipping meta.* keys (waggle-internal bookkeeping).
+// Matches the Tail UI's zerolog-style attribute rendering.
+func writeLogfmtAttrs(sb *strings.Builder, attrsJSON string) {
+	if attrsJSON == "" || attrsJSON == "{}" {
+		return
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(attrsJSON), &raw); err != nil {
+		return
+	}
+	for k, v := range raw {
+		if strings.HasPrefix(k, "meta.") {
+			continue
+		}
+		sb.WriteByte(' ')
+		sb.WriteString(k)
+		sb.WriteByte('=')
+		writeLogfmtScalar(sb, v)
+	}
+}
+
+func writeLogfmtScalar(sb *strings.Builder, v any) {
+	switch t := v.(type) {
+	case string:
+		writeLogfmtValue(sb, t)
+	case nil:
+		sb.WriteString("null")
+	case float64:
+		// json.Unmarshal gives all numbers as float64. Render integers
+		// without a trailing .0 so `pid=37556` looks right.
+		if t == float64(int64(t)) {
+			fmt.Fprintf(sb, "%d", int64(t))
+		} else {
+			fmt.Fprintf(sb, "%v", t)
+		}
+	case bool:
+		if t {
+			sb.WriteString("true")
+		} else {
+			sb.WriteString("false")
+		}
+	default:
+		// Objects/arrays: inline as JSON so nothing is lost.
+		b, _ := json.Marshal(t)
+		sb.Write(b)
+	}
+}
+
+func writeLogfmtValue(sb *strings.Builder, s string) {
+	// logfmt quoting rule: wrap in double quotes if the value contains
+	// whitespace, `=`, or `"`. Escape embedded quotes and backslashes.
+	if s == "" {
+		sb.WriteString(`""`)
+		return
+	}
+	needsQuote := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '=' || c == '"' {
+			needsQuote = true
+			break
+		}
+	}
+	if !needsQuote {
+		sb.WriteString(s)
+		return
+	}
+	sb.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '"', '\\':
+			sb.WriteByte('\\')
+			sb.WriteByte(c)
+		case '\n':
+			sb.WriteString(`\n`)
+		default:
+			sb.WriteByte(c)
+		}
+	}
+	sb.WriteByte('"')
+}


### PR DESCRIPTION
## Summary

Adds a passthrough log mirror so you can run a terminal-side view of logs alongside the Waggle UI — or capture logs to disk for later investigation without relying on the SQLite retention window.

```
--tee <path|->            # mirror path, "-" for stdout
--tee-service a,b         # service.name allow-list, comma-separated (optional)
--tee-severity warn       # severity floor: trace|debug|info|warn|error|fatal
--tee-format console|logfmt|json
--tee-color auto|always|never    # console format only
```

All flags also available as `WAGGLE_TEE*` env vars.

## Common shapes

**Watch logs in a terminal while exploring traces/metrics in the browser**
```sh
waggle --tee - \
  --tee-service api-gateway,payments \
  --tee-severity warn
```

**Save logs for later investigation**
```sh
waggle --tee logs/waggle.logfmt --tee-format logfmt
waggle --tee logs/waggle.ndjson --tee-format json
waggle --tee - --tee-color always | less -R
```

## Implementation notes

- Hooked at `handleLogs` (not inside the writer) — only log records flow through. Spans + metrics are unchanged.
- `console` matches the Tail tab visually (zerolog-ish): timestamp, bold severity pill, dim service, bold body, cyan keys. On ERROR-level rows, `error` / `exception.*` values get the bold-red highlight.
- Colour `auto` = TTY-detect via `golang.org/x/term` on stdout. Never colours files.
- Best-effort: write errors are logged once and the ingest path keeps serving. Tee never blocks `/v1/logs` or holds the writer connection.
- README has a new "Tee logs to a terminal or file" subsection + the flags in the Config table.

## Test plan

- [x] `go build ./...` clean
- [x] `--tee -` with a loadgen stream renders matching UI format
- [x] `--tee-service`, `--tee-severity`, `--tee-format logfmt`/`json` all behave
- [x] `--tee-color always` emits ANSI when piped; `--tee-color never` on TTY strips it
- [x] Store is unaffected (count queries match with and without tee)
- [x] Tee close flushes buffer on shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)