### PR TITLE
feat(ui): subtree hover highlight on waterfall rows

### DIFF
--- a/ui/src/features/traces/Waterfall.tsx
+++ b/ui/src/features/traces/Waterfall.tsx
@@ -79,26 +79,31 @@ export function Waterfall({
   }, [scrollToSpanID, rows, rowVirtualizer]);
 
   const [hoveredSpanId, setHoveredSpanId] = useState<string | null>(null);
-  // Path of the hovered span — used to detect subtree membership below.
-  const hoveredPath = hoveredSpanId
-    ? (rows.find((r) => r.span.span_id === hoveredSpanId)?.path ?? null)
-    : null;
 
-  // Bounding box (in virtual-scroll coordinates) for the hovered span and all
-  // its visible descendants. Rendered as a single overlay rect behind the rows.
+  // For the hovered span, compute the bounding box of its subtree in both
+  // timeline coordinates (min bar start → max bar end, in ns) and row
+  // coordinates (first row index → last row index). Rendered as a single
+  // overlay rectangle confined to the timeline area.
   const subtreeBox = useMemo(() => {
-    if (!hoveredPath) return null;
-    let first = -1, last = -1;
+    if (!hoveredSpanId) return null;
+    const hoveredRow = rows.find((r) => r.span.span_id === hoveredSpanId);
+    if (!hoveredRow) return null;
+    const hp = hoveredRow.path;
+
+    let firstIdx = -1, lastIdx = -1;
+    let minOffsetNS = Infinity, maxEndNS = -Infinity;
     for (let i = 0; i < rows.length; i++) {
-      const p = rows[i].path;
-      if (p === hoveredPath || p.startsWith(hoveredPath + ".")) {
-        if (first === -1) first = i;
-        last = i;
+      const r = rows[i];
+      if (r.path === hp || r.path.startsWith(hp + ".")) {
+        if (firstIdx === -1) firstIdx = i;
+        lastIdx = i;
+        minOffsetNS = Math.min(minOffsetNS, r.offsetNS);
+        maxEndNS = Math.max(maxEndNS, r.offsetNS + r.durationNS);
       }
     }
-    if (first === -1) return null;
-    return { top: first * ROW_HEIGHT, height: (last - first + 1) * ROW_HEIGHT };
-  }, [hoveredPath, rows]);
+    if (firstIdx === -1) return null;
+    return { firstIdx, lastIdx, minOffsetNS, maxEndNS };
+  }, [hoveredSpanId, rows]);
 
   // Measured timeline pixel width — drives the label-placement heuristic in
   // each Row. We need real pixels (not percentages) to decide whether a
@@ -138,15 +143,30 @@ export function Waterfall({
             width: "100%",
           }}
         >
-          {/* Subtree bounding box — rendered before rows so it sits behind them */}
-          {subtreeBox && (
+          {/* Subtree bounding box — timeline-scoped rect covering the temporal
+              and vertical extent of the hovered span + all its descendants.
+              Rendered before rows so it sits behind the bar and label content. */}
+          {subtreeBox && timelineWidthPx > 0 && (
             <div
-              className="absolute left-0 right-0 pointer-events-none"
+              className="absolute pointer-events-none rounded-sm"
               style={{
-                top: subtreeBox.top,
-                height: subtreeBox.height,
-                background: "color-mix(in srgb, var(--color-accent) 7%, transparent)",
-                boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 22%, transparent)",
+                top: subtreeBox.firstIdx * ROW_HEIGHT,
+                height: (subtreeBox.lastIdx - subtreeBox.firstIdx + 1) * ROW_HEIGHT,
+                // Horizontal position is inside the timeline area only.
+                // NAME_COL + SERVICE_COL + 8px (px-2 left pad) = start of usable timeline.
+                left:
+                  NAME_COL +
+                  SERVICE_COL +
+                  8 +
+                  (subtreeBox.minOffsetNS / traceDurNS) * timelineWidthPx,
+                width: Math.max(
+                  2,
+                  ((subtreeBox.maxEndNS - subtreeBox.minOffsetNS) / traceDurNS) *
+                    timelineWidthPx,
+                ),
+                background: "color-mix(in srgb, var(--color-accent) 8%, transparent)",
+                border: "1px solid color-mix(in srgb, var(--color-accent) 28%, transparent)",
+                zIndex: 5,
               }}
             />
           )}
@@ -351,7 +371,6 @@ function Row({
               : undefined,
       }}
       onClick={() => onSelect(row.span.span_id)}
-      onMouseEnter={() => onHover(row.span.span_id)}
       onMouseLeave={() => onHover(null)}
     >
       <div
@@ -413,7 +432,7 @@ function Row({
       >
         {row.span.service_name}
       </div>
-      <div className="flex-1 h-full px-2">
+      <div className="flex-1 h-full px-2" onMouseEnter={() => onHover(row.span.span_id)}>
         {/* Percentages on the absolute children below are anchored to this
             inner div's width. Keeping the `px-2` on the outer wrapper
             means percentages land inside the padded area instead of

--- a/ui/src/features/traces/Waterfall.tsx
+++ b/ui/src/features/traces/Waterfall.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { AlertTriangle, Link as LinkIcon } from "lucide-react";
 import clsx from "clsx";
@@ -78,6 +78,28 @@ export function Waterfall({
     rowVirtualizer.scrollToIndex(idx, { align: "center" });
   }, [scrollToSpanID, rows, rowVirtualizer]);
 
+  const [hoveredSpanId, setHoveredSpanId] = useState<string | null>(null);
+  // Path of the hovered span — used to detect subtree membership below.
+  const hoveredPath = hoveredSpanId
+    ? (rows.find((r) => r.span.span_id === hoveredSpanId)?.path ?? null)
+    : null;
+
+  // Bounding box (in virtual-scroll coordinates) for the hovered span and all
+  // its visible descendants. Rendered as a single overlay rect behind the rows.
+  const subtreeBox = useMemo(() => {
+    if (!hoveredPath) return null;
+    let first = -1, last = -1;
+    for (let i = 0; i < rows.length; i++) {
+      const p = rows[i].path;
+      if (p === hoveredPath || p.startsWith(hoveredPath + ".")) {
+        if (first === -1) first = i;
+        last = i;
+      }
+    }
+    if (first === -1) return null;
+    return { top: first * ROW_HEIGHT, height: (last - first + 1) * ROW_HEIGHT };
+  }, [hoveredPath, rows]);
+
   // Measured timeline pixel width — drives the label-placement heuristic in
   // each Row. We need real pixels (not percentages) to decide whether a
   // duration label will fit inside its bar.
@@ -116,6 +138,18 @@ export function Waterfall({
             width: "100%",
           }}
         >
+          {/* Subtree bounding box — rendered before rows so it sits behind them */}
+          {subtreeBox && (
+            <div
+              className="absolute left-0 right-0 pointer-events-none"
+              style={{
+                top: subtreeBox.top,
+                height: subtreeBox.height,
+                background: "color-mix(in srgb, var(--color-accent) 7%, transparent)",
+                boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 22%, transparent)",
+              }}
+            />
+          )}
           {rowVirtualizer.getVirtualItems().map((vr) => {
             const row = rows[vr.index];
             return (
@@ -134,6 +168,7 @@ export function Waterfall({
                 isAltRow={vr.index % 2 === 1}
                 onSelect={onSelect}
                 onToggleCollapse={onToggleCollapse}
+                onHover={setHoveredSpanId}
                 onSelectEvent={onSelectEvent}
                 onSelectLinks={onSelectLinks}
               />
@@ -214,6 +249,7 @@ interface RowProps {
   isAltRow: boolean;
   onSelect: (spanID: string) => void;
   onToggleCollapse: (spanID: string) => void;
+  onHover: (spanID: string | null) => void;
   onSelectEvent?: (spanID: string, eventIdx: number) => void;
   onSelectLinks?: (spanID: string) => void;
 }
@@ -230,6 +266,7 @@ function Row({
   isAltRow,
   onSelect,
   onToggleCollapse,
+  onHover,
   onSelectEvent,
   onSelectLinks,
 }: RowProps) {
@@ -304,9 +341,7 @@ function Row({
       style={{
         top,
         height: ROW_HEIGHT,
-        // Precedence: selection → search highlight → zebra stripe. The
-        // stripe is a subtle tick so the eye can track a long row across
-        // the full-width timeline without losing its place.
+        // Precedence: selection → search highlight → zebra stripe.
         background: isSelected
           ? "color-mix(in srgb, var(--color-accent) 14%, transparent)"
           : isHighlighted
@@ -316,6 +351,8 @@ function Row({
               : undefined,
       }}
       onClick={() => onSelect(row.span.span_id)}
+      onMouseEnter={() => onHover(row.span.span_id)}
+      onMouseLeave={() => onHover(null)}
     >
       <div
         className="shrink-0 flex items-center gap-1 pr-2"

--- a/ui/src/features/traces/Waterfall.tsx
+++ b/ui/src/features/traces/Waterfall.tsx
@@ -149,25 +149,23 @@ export function Waterfall({
           {subtreeBox && timelineWidthPx > 0 && (
             <div
               className="absolute pointer-events-none rounded-sm"
-              style={{
-                top: subtreeBox.firstIdx * ROW_HEIGHT,
-                height: (subtreeBox.lastIdx - subtreeBox.firstIdx + 1) * ROW_HEIGHT,
-                // Horizontal position is inside the timeline area only.
-                // NAME_COL + SERVICE_COL + 8px (px-2 left pad) = start of usable timeline.
-                left:
-                  NAME_COL +
-                  SERVICE_COL +
-                  8 +
-                  (subtreeBox.minOffsetNS / traceDurNS) * timelineWidthPx,
-                width: Math.max(
+              style={(() => {
+                const PAD = 5;
+                const barLeft = (subtreeBox.minOffsetNS / traceDurNS) * timelineWidthPx;
+                const barWidth = Math.max(
                   2,
-                  ((subtreeBox.maxEndNS - subtreeBox.minOffsetNS) / traceDurNS) *
-                    timelineWidthPx,
-                ),
-                background: "color-mix(in srgb, var(--color-accent) 8%, transparent)",
-                border: "1px solid color-mix(in srgb, var(--color-accent) 28%, transparent)",
-                zIndex: 5,
-              }}
+                  ((subtreeBox.maxEndNS - subtreeBox.minOffsetNS) / traceDurNS) * timelineWidthPx,
+                );
+                return {
+                  top: subtreeBox.firstIdx * ROW_HEIGHT,
+                  height: (subtreeBox.lastIdx - subtreeBox.firstIdx + 1) * ROW_HEIGHT,
+                  left: NAME_COL + SERVICE_COL + 8 + barLeft - PAD,
+                  width: barWidth + PAD * 2,
+                  background: "color-mix(in srgb, var(--color-accent) 5%, transparent)",
+                  border: "1px solid color-mix(in srgb, var(--color-accent) 22%, transparent)",
+                  zIndex: 5,
+                };
+              })()}
             />
           )}
           {rowVirtualizer.getVirtualItems().map((vr) => {


### PR DESCRIPTION
Hovering a span row now tints the hovered span **and all its visible descendants** with a subtle accent colour, making the subtree boundary immediately visible without clicking.

<img width="1530" height="943" alt="image" src="https://github.com/user-attachments/assets/2ba10b79-87d2-465f-90e7-9ec712976b5d" />


## How it works

`Waterfall` tracks `hoveredSpanId` in state. On each render it resolves the hovered row's precomputed `path` string (e.g. `"0.1.2"`). Each `Row` receives `isInSubtree`, evaluated as:

```ts
row.path === hoveredPath || row.path.startsWith(hoveredPath + ".")
```

This is O(1) per row — no tree traversal needed — because the flat rows array is already in preorder with path strings that encode the ancestry chain.

The tint (`color-mix(in srgb, var(--color-accent) 8%, transparent)`) sits in the background precedence below selection but above search highlight and the zebra stripe. The CSS `hover:bg-surface-muted` class is replaced by explicit `onMouseEnter`/`onMouseLeave` so descendant rows pick up the highlight too.