### PR TITLE
feat(ui): wire span-attribute "filter by" back to source query

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -33,6 +35,7 @@ func (rt *Router) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/logs/search", rt.searchLogs)
 	mux.HandleFunc("POST /api/query", rt.runQuery)
 	mux.HandleFunc("GET /api/history", rt.listHistory)
+	mux.HandleFunc("GET /api/history/{hash}", rt.getHistoryByHash)
 	mux.HandleFunc("POST /api/clear", rt.clear)
 }
 
@@ -60,28 +63,65 @@ func (rt *Router) runQuery(w http.ResponseWriter, r *http.Request) {
 	// Record the run in query_history (best-effort — don't fail the user
 	// query on a history bookkeeping error). Skip raw-rows mode; a bare
 	// "browse the table" isn't something the user wants back in their
-	// recent-queries list.
+	// recent-queries list. Surface the hash on the response so the UI
+	// can thread it through trace links as a source-query shortcode.
 	if len(q.Select) > 0 {
-		rt.recordHistory(r.Context(), &q)
+		if hash := rt.recordHistory(r.Context(), &q); hash != nil {
+			res.HistoryHash = hex.EncodeToString(hash)
+		}
 	}
 	writeJSON(w, http.StatusOK, res)
 }
 
-func (rt *Router) recordHistory(ctx context.Context, q *query.Query) {
+// recordHistory upserts the run into query_history and returns the
+// content hash. Returns nil on any bookkeeping error — the caller
+// continues regardless.
+func (rt *Router) recordHistory(ctx context.Context, q *query.Query) []byte {
 	hash, err := query.HashQuery(q)
 	if err != nil {
 		rt.log.Debug("history hash failed", "err", err)
-		return
+		return nil
 	}
 	raw, err := json.Marshal(q)
 	if err != nil {
 		rt.log.Debug("history marshal failed", "err", err)
-		return
+		return nil
 	}
 	display := query.FormatDisplay(q)
 	if err := rt.store.RecordQueryRun(ctx, string(q.Dataset), string(raw), display, hash); err != nil {
 		rt.log.Debug("history write failed", "err", err)
+		return nil
 	}
+	return hash
+}
+
+// getHistoryByHash returns a single query_history entry keyed by the
+// hex-encoded SHA-256 content hash. Used by the trace-view "filter by"
+// flow to recover the originating query without round-tripping the
+// full QuerySearch through the URL.
+func (rt *Router) getHistoryByHash(w http.ResponseWriter, r *http.Request) {
+	raw := strings.ToLower(r.PathValue("hash"))
+	hash, err := hex.DecodeString(raw)
+	if err != nil || len(hash) != 32 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error": "invalid hash: expected 64 lowercase hex characters",
+			"hash":  raw,
+		})
+		return
+	}
+	entry, err := rt.store.GetQueryHistoryByHash(r.Context(), hash)
+	if errors.Is(err, store.ErrNotFound) {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"error": "query history entry not found",
+			"hash":  raw,
+		})
+		return
+	}
+	if err != nil {
+		rt.writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, entry)
 }
 
 func (rt *Router) listHistory(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -647,6 +647,73 @@ func anyInt(v any) int64 {
 	return 0
 }
 
+func TestAPI_HistoryByHash(t *testing.T) {
+	f := newAPIFixture(t)
+
+	// Need a query run on disk before there's a hash to look up. Seed one
+	// span so the query has something to count.
+	now := time.Now().UnixNano()
+	batch := store.Batch{
+		Resources: []store.Resource{{ID: 1, ServiceName: "widget",
+			AttributesJSON: `{"service.name":"widget"}`, FirstSeenNS: now, LastSeenNS: now}},
+		Scopes: []store.Scope{{ID: 1, Name: "lib"}},
+		Events: []store.Event{spanEvent(
+			[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			[]byte{1, 1, 1, 1, 1, 1, 1, 1}, nil,
+			"widget", "GET /", "SERVER", 0, now, now+1_000_000, "", "{}"),
+		},
+	}
+	if err := f.st.WriteBatch(f.ctx, batch); err != nil {
+		t.Fatal(err)
+	}
+
+	body := fmt.Sprintf(`{
+		"dataset":"spans",
+		"time_range":{"from":%d,"to":%d},
+		"select":[{"op":"count"}]
+	}`, now-1_000_000_000, now+1_000_000_000)
+
+	var run store.QueryResult
+	if status := postJSON(t, f.srv.URL+"/api/query", body, &run); status != http.StatusOK {
+		t.Fatalf("query status %d", status)
+	}
+	if run.HistoryHash == "" {
+		t.Fatalf("expected history_hash on query response, got empty")
+	}
+	if len(run.HistoryHash) != 64 {
+		t.Errorf("history_hash length: want 64, got %d (%q)", len(run.HistoryHash), run.HistoryHash)
+	}
+
+	// Happy path: round-trip the hash.
+	var entry store.QueryHistoryEntry
+	if status := f.getJSON("/api/history/"+run.HistoryHash, &entry); status != http.StatusOK {
+		t.Fatalf("get-by-hash status %d", status)
+	}
+	if entry.Dataset != "spans" {
+		t.Errorf("dataset: want spans, got %q", entry.Dataset)
+	}
+	if entry.RunCount < 1 {
+		t.Errorf("run_count: want >=1, got %d", entry.RunCount)
+	}
+	if !strings.Contains(entry.QueryJSON, `"dataset":"spans"`) {
+		t.Errorf("query_json missing dataset: %q", entry.QueryJSON)
+	}
+
+	// 400 on malformed hex.
+	if status := f.getJSON("/api/history/notahash", nil); status != http.StatusBadRequest {
+		t.Errorf("malformed hash: want 400, got %d", status)
+	}
+	// 400 on wrong length (32 hex chars = 16 bytes, not 32).
+	if status := f.getJSON("/api/history/0102030405060708090a0b0c0d0e0f10", nil); status != http.StatusBadRequest {
+		t.Errorf("short hash: want 400, got %d", status)
+	}
+	// 404 on a well-formed but unknown hash.
+	bogus := strings.Repeat("ab", 32)
+	if status := f.getJSON("/api/history/"+bogus, nil); status != http.StatusNotFound {
+		t.Errorf("unknown hash: want 404, got %d", status)
+	}
+}
+
 func TestAPI_Traces_Pagination(t *testing.T) {
 	f := newAPIFixture(t)
 

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -222,6 +222,11 @@ type QueryResult struct {
 	Rows      [][]any       `json:"rows"`
 	HasBucket bool          `json:"has_bucket"`
 	GroupKeys []string      `json:"group_keys,omitempty"`
+	// HistoryHash is the hex-encoded query_history content hash for this
+	// run. Set by the API layer after RunQuery — the store doesn't
+	// populate it. Used by the UI to round-trip a "filter by" click in
+	// the trace view back to the originating query.
+	HistoryHash string `json:"history_hash,omitempty"`
 }
 
 // QueryHistoryEntry is one dedup'd row in the query_history table — the

--- a/internal/store/sqlite/queries.go
+++ b/internal/store/sqlite/queries.go
@@ -1267,6 +1267,26 @@ func (s *Store) RecordQueryRun(ctx context.Context, dataset, queryJSON, displayT
 	return nil
 }
 
+// GetQueryHistoryByHash fetches a single query_history row by its
+// content hash. Returns store.ErrNotFound when the row was pruned out
+// or never existed.
+func (s *Store) GetQueryHistoryByHash(ctx context.Context, hash []byte) (store.QueryHistoryEntry, error) {
+	const q = `SELECT id, dataset, query_json, display_text, run_count, first_run_ns, last_run_ns
+		FROM query_history WHERE hash = ?`
+	var e store.QueryHistoryEntry
+	err := s.reader.QueryRowContext(ctx, q, hash).Scan(
+		&e.ID, &e.Dataset, &e.QueryJSON, &e.DisplayText,
+		&e.RunCount, &e.FirstRunNS, &e.LastRunNS,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.QueryHistoryEntry{}, store.ErrNotFound
+	}
+	if err != nil {
+		return store.QueryHistoryEntry{}, err
+	}
+	return e, nil
+}
+
 // ListQueryHistory returns rows ordered by last_run_ns DESC, capped at limit.
 func (s *Store) ListQueryHistory(ctx context.Context, limit int) ([]store.QueryHistoryEntry, error) {
 	if limit <= 0 || limit > queryHistoryCap {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,6 +1,14 @@
 package store
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotFound is returned by lookup-style methods (e.g. by-hash query
+// history) when the requested row doesn't exist. Callers map this to
+// HTTP 404 at the API layer.
+var ErrNotFound = errors.New("not found")
 
 // TraceFilter scopes the trace list query.
 type TraceFilter struct {
@@ -74,6 +82,10 @@ type Store interface {
 	// `limit`. No cursor pagination yet — the set is bounded by the prune
 	// cap in RecordQueryRun.
 	ListQueryHistory(ctx context.Context, limit int) ([]QueryHistoryEntry, error)
+	// GetQueryHistoryByHash fetches a single dedup'd row by its content
+	// hash. Returns ErrNotFound when the hash isn't present (which can
+	// happen if the row was pruned out by the query_history cap).
+	GetQueryHistoryByHash(ctx context.Context, hash []byte) (QueryHistoryEntry, error)
 
 	Retain(ctx context.Context, olderThanNS int64) error
 	Clear(ctx context.Context) error

--- a/ui/src/components/ui/AttributesPanel.tsx
+++ b/ui/src/components/ui/AttributesPanel.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { Filter as FilterIcon, Search } from "lucide-react";
 import type { Filter } from "../../lib/query";
 
@@ -19,12 +18,13 @@ interface Props {
   /** Placeholder for the filter input. */
   filterPlaceholder?: string;
   /**
-   * Where clicking the filter button on a scalar row navigates to. The
-   * query builder's URL schema is shared across /traces, /logs, and
-   * /metrics — the caller picks the dataset-appropriate route. Defaults
-   * to /traces.
+   * Click handler for the per-row filter button. The panel is purely
+   * presentational — the caller owns navigation and how the new filter
+   * is merged into the page's WHERE clause (append vs replace,
+   * cross-route navigation, etc). When omitted, the filter button is
+   * hidden so users don't see a no-op affordance.
    */
-  filterTarget?: "/traces" | "/logs" | "/metrics";
+  onFilter?: (filter: Filter) => void;
 }
 
 /**
@@ -39,9 +39,8 @@ export function AttributesPanel({
   rows,
   attributesJson,
   filterPlaceholder = "Filter fields and values",
-  filterTarget = "/traces",
+  onFilter,
 }: Props) {
-  const navigate = useNavigate();
   const [filter, setFilter] = useState("");
 
   const allRows = rows ?? parseAttributes(attributesJson ?? "{}");
@@ -49,11 +48,7 @@ export function AttributesPanel({
   const applyFilter = (row: AttrRow) => {
     const value = filterableValue(row);
     if (value === null) return;
-    const f: Filter = { field: row.key, op: "=", value };
-    navigate({
-      to: filterTarget,
-      search: { where: [f] } as unknown as Record<string, unknown>,
-    });
+    onFilter?.({ field: row.key, op: "=", value });
   };
 
   const f = filter.toLowerCase();
@@ -100,12 +95,12 @@ export function AttributesPanel({
                 >
                   {r.key}
                 </span>
-                {canFilter && (
+                {canFilter && onFilter && (
                   <button
                     type="button"
                     onClick={() => applyFilter(r)}
                     className="ml-auto opacity-0 group-hover:opacity-100 shrink-0 p-1 rounded hover:bg-[var(--color-card-hover)]"
-                    title={`Filter ${filterTarget} to ${r.key} = ${String(r.value)}`}
+                    title={`Filter on ${r.key} = ${String(r.value)}`}
                   >
                     <FilterIcon
                       className="w-3 h-3"

--- a/ui/src/features/query/EventsTable.tsx
+++ b/ui/src/features/query/EventsTable.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { X } from "lucide-react";
 import type {
   Dataset,
+  Filter,
   QueryColumn,
   QueryResult,
   QuerySearch,
@@ -21,10 +22,19 @@ export interface SelectedRow {
   columns: QueryColumn[];
 }
 
+type TabID = "overview" | "traces" | "explore" | "tail";
+
 interface Props {
   dataset: Dataset;
   querySearch: QuerySearch;
   runCount: number;
+  /** Hex content-hash of the originating chart query, threaded into the
+   *  trace links so the trace view's "filter by" affordance can return
+   *  to this query. Null while a fresh query is in flight. */
+  historyHash?: string | null;
+  /** Active /events tab when the trace link was rendered. Round-tripped
+   *  through the trace URL so filter-by lands the user back here. */
+  currentTab?: TabID;
   /** Reports the scroll container's vertical offset on every scroll event so
    *  the page can collapse the query/chart header once the user drills in. */
   onScrollY?: (y: number) => void;
@@ -40,7 +50,16 @@ interface Props {
  * dataset + WHERE + time range. Backed by the same /api/query endpoint the
  * chart uses; empty SELECT switches that endpoint into raw-rows mode.
  */
-export function EventsTable({ dataset, querySearch, runCount, onScrollY, selected, onSelect }: Props) {
+export function EventsTable({
+  dataset,
+  querySearch,
+  runCount,
+  historyHash = null,
+  currentTab = "explore",
+  onScrollY,
+  selected,
+  onSelect,
+}: Props) {
   const result = useQuery({
     queryKey: [
       "events",
@@ -88,7 +107,14 @@ export function EventsTable({ dataset, querySearch, runCount, onScrollY, selecte
   }
 
   if (dataset === "spans") {
-    return <SpansTable result={result.data!} onScrollY={onScrollY} />;
+    return (
+      <SpansTable
+        result={result.data!}
+        onScrollY={onScrollY}
+        historyHash={historyHash}
+        currentTab={currentTab}
+      />
+    );
   }
   if (dataset === "metrics") {
     return (
@@ -106,6 +132,8 @@ export function EventsTable({ dataset, querySearch, runCount, onScrollY, selecte
       onScrollY={onScrollY}
       selected={selected ?? null}
       onSelect={onSelect}
+      historyHash={historyHash}
+      currentTab={currentTab}
     />
   );
 }
@@ -117,9 +145,13 @@ export function EventsTable({ dataset, querySearch, runCount, onScrollY, selecte
 function SpansTable({
   result,
   onScrollY,
+  historyHash,
+  currentTab,
 }: {
   result: QueryResult;
   onScrollY?: (y: number) => void;
+  historyHash: string | null;
+  currentTab: TabID;
 }) {
   const idx = columnIndex(result);
   return (
@@ -171,6 +203,10 @@ function SpansTable({
                       <Link
                         to="/traces/$traceId"
                         params={{ traceId: traceID }}
+                        search={{
+                          ...(historyHash ? { from: historyHash } : {}),
+                          tab: currentTab,
+                        }}
                         className="underline font-mono text-xs"
                         style={{ color: "var(--color-accent)" }}
                       >
@@ -198,11 +234,15 @@ function LogsTable({
   onScrollY,
   selected,
   onSelect,
+  historyHash,
+  currentTab,
 }: {
   result: QueryResult;
   onScrollY?: (y: number) => void;
   selected: SelectedRow | null;
   onSelect?: (next: SelectedRow | null) => void;
+  historyHash: string | null;
+  currentTab: TabID;
 }) {
   const idx = columnIndex(result);
   const selectedRef = selected?.row;
@@ -270,7 +310,11 @@ function LogsTable({
                       <Link
                         to="/traces/$traceId"
                         params={{ traceId: traceID }}
-                        search={spanID ? { span: spanID } : {}}
+                        search={{
+                          ...(spanID ? { span: spanID } : {}),
+                          ...(historyHash ? { from: historyHash } : {}),
+                          tab: currentTab,
+                        }}
                         className="underline"
                         style={{ color: "var(--color-accent)" }}
                       >
@@ -300,10 +344,20 @@ export function LogDetailPane({
   columns,
   row,
   onClose,
+  onFilter,
+  historyHash = null,
+  currentTab = "explore",
 }: {
   columns: QueryColumn[];
   row: unknown[];
   onClose: () => void;
+  /** Append-and-rerun callback for the per-attribute filter button. */
+  onFilter?: (filter: Filter) => void;
+  /** Source-query hash propagated to the trace link in this pane. */
+  historyHash?: string | null;
+  /** Active tab when this pane was opened — round-tripped through the
+   *  trace link so filter-by lands the user back on this tab. */
+  currentTab?: TabID;
 }) {
   const idx = columnIndexFromColumns(columns);
   const timeNS = Number(row[idx.time_ns] ?? 0);
@@ -354,7 +408,11 @@ export function LogDetailPane({
             <Link
               to="/traces/$traceId"
               params={{ traceId: traceID }}
-              search={spanID ? { span: spanID } : {}}
+              search={{
+                ...(spanID ? { span: spanID } : {}),
+                ...(historyHash ? { from: historyHash } : {}),
+                tab: currentTab,
+              }}
               className="underline truncate"
               style={{ color: "var(--color-accent)" }}
             >
@@ -365,7 +423,7 @@ export function LogDetailPane({
         ) : null}
       </div>
       <div className="flex-1 overflow-auto">
-        <AttributesPanel attributesJson={attributes} filterTarget="/logs" />
+        <AttributesPanel attributesJson={attributes} onFilter={onFilter} />
       </div>
     </PaneShell>
   );
@@ -465,10 +523,13 @@ export function MetricDetailPane({
   columns,
   row,
   onClose,
+  onFilter,
 }: {
   columns: QueryColumn[];
   row: unknown[];
   onClose: () => void;
+  /** Append-and-rerun callback for the per-attribute filter button. */
+  onFilter?: (filter: Filter) => void;
 }) {
   const idx = columnIndexFromColumns(columns);
   const timeNS = Number(row[idx.time_ns] ?? 0);
@@ -511,7 +572,7 @@ export function MetricDetailPane({
         </div>
       </div>
       <div className="flex-1 overflow-auto">
-        <AttributesPanel attributesJson={attributes} filterTarget="/metrics" />
+        <AttributesPanel attributesJson={attributes} onFilter={onFilter} />
       </div>
     </PaneShell>
   );

--- a/ui/src/features/query/ResultTabs.tsx
+++ b/ui/src/features/query/ResultTabs.tsx
@@ -17,6 +17,11 @@ interface Props {
   /** Increments on every Run click, forcing a refetch even when params
    *  are unchanged since the last run. */
   runCount: number;
+  /** Hex content-hash of the last successful chart run. Threaded into
+   *  trace links so the trace view's "filter by" can return to the
+   *  originating query. Null while a query is in flight or hasn't been
+   *  recorded (e.g. raw-rows mode with empty SELECT). */
+  historyHash?: string | null;
   onTabChange: (tab: TabID) => void;
   /** Optional slot for a logs-only FTS search input rendered next to tabs. */
   rightSlot?: React.ReactNode;
@@ -53,6 +58,7 @@ export function ResultTabs({
   search,
   querySearch,
   runCount,
+  historyHash,
   onTabChange,
   rightSlot,
   onExploreScrollY,
@@ -108,12 +114,21 @@ export function ResultTabs({
       </div>
       <div className="flex-1 overflow-hidden">
         {active === "overview" && <OverviewTab dataset={dataset} querySearch={querySearch} runCount={runCount} />}
-        {active === "traces" && <TracesTab querySearch={querySearch} runCount={runCount} />}
+        {active === "traces" && (
+          <TracesTab
+            querySearch={querySearch}
+            runCount={runCount}
+            historyHash={historyHash ?? null}
+            currentTab={active}
+          />
+        )}
         {active === "explore" && (
           <EventsTable
             dataset={dataset}
             querySearch={querySearch}
             runCount={runCount}
+            historyHash={historyHash ?? null}
+            currentTab={active}
             onScrollY={onExploreScrollY}
             selected={selectedRow ?? null}
             onSelect={onSelectRow}

--- a/ui/src/features/query/TracesTab.tsx
+++ b/ui/src/features/query/TracesTab.tsx
@@ -6,9 +6,19 @@ import { serviceColor } from "../../lib/colors";
 import { formatDuration, formatRelativeTimestamp } from "../../lib/format";
 import { CopyButton } from "../../components/ui/CopyButton";
 
+type TabID = "overview" | "traces" | "explore" | "tail";
+
 interface Props {
   querySearch: QuerySearch;
   runCount: number;
+  /** Hex content-hash of the originating chart query, threaded into the
+   *  trace links so the trace view's "filter by" affordance can return
+   *  to this query. Null while a fresh query is in flight. */
+  historyHash?: string | null;
+  /** Active /events tab when the trace link was rendered. Round-tripped
+   *  through the trace URL so filter-by lands the user back on the
+   *  originating tab. */
+  currentTab?: TabID;
 }
 
 /**
@@ -17,7 +27,12 @@ interface Props {
  * Each row is one trace (by virtue of being its root span) and links into
  * the full waterfall view.
  */
-export function TracesTab({ querySearch, runCount }: Props) {
+export function TracesTab({
+  querySearch,
+  runCount,
+  historyHash = null,
+  currentTab = "traces",
+}: Props) {
   const result = useQuery({
     queryKey: ["traces-tab", querySearch, runCount],
     queryFn: ({ signal }) => {
@@ -81,7 +96,13 @@ export function TracesTab({ querySearch, runCount }: Props) {
         </thead>
         <tbody>
           {data.rows.map((row, i) => (
-            <TraceRow key={i} row={row} result={data} />
+            <TraceRow
+              key={i}
+              row={row}
+              result={data}
+              historyHash={historyHash}
+              currentTab={currentTab}
+            />
           ))}
         </tbody>
       </table>
@@ -89,7 +110,17 @@ export function TracesTab({ querySearch, runCount }: Props) {
   );
 }
 
-function TraceRow({ row, result }: { row: unknown[]; result: QueryResult }) {
+function TraceRow({
+  row,
+  result,
+  historyHash,
+  currentTab,
+}: {
+  row: unknown[];
+  result: QueryResult;
+  historyHash: string | null;
+  currentTab: TabID;
+}) {
   const col = (name: string) => result.columns.findIndex((c) => c.name === name);
 
   const traceID = String(row[col("trace_id")] ?? "").toLowerCase();
@@ -128,6 +159,10 @@ function TraceRow({ row, result }: { row: unknown[]; result: QueryResult }) {
             <Link
               to="/traces/$traceId"
               params={{ traceId: traceID }}
+              search={{
+                ...(historyHash ? { from: historyHash } : {}),
+                tab: currentTab,
+              }}
               className="underline font-mono text-xs"
               style={{ color: "var(--color-accent)" }}
             >

--- a/ui/src/features/traces/SpanDetail.tsx
+++ b/ui/src/features/traces/SpanDetail.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import * as Tabs from "@radix-ui/react-tabs";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, ExternalLink } from "lucide-react";
-import type { SpanOut, TraceDetail, TraceResource } from "../../lib/api";
+import { api, HttpError, type SpanOut, type TraceDetail, type TraceResource } from "../../lib/api";
 import { serviceColor } from "../../lib/colors";
 import { formatDuration } from "../../lib/format";
 import { spanStatusLabel } from "./tree";
@@ -15,6 +15,12 @@ import {
   parseAttributes,
   type AttrRow,
 } from "../../components/ui/AttributesPanel";
+import {
+  appendWhere,
+  queryToUrlSearch,
+  type Filter,
+  type Query,
+} from "../../lib/query";
 
 interface Props {
   span: SpanOut | null;
@@ -27,6 +33,25 @@ interface Props {
   activeTab?: string;
   /** Fires when the user clicks a tab header. Parent should sync its state. */
   onTabChange?: (tab: string) => void;
+  /**
+   * Hex content-hash of the originating /events query. When set, the
+   * filter button on attribute rows fetches the source query from
+   * /api/history/<hash>, appends the new filter to its WHERE, and
+   * navigates to /events with the merged search. When unset (or the
+   * server says 404 because the row was pruned), we fall back to a
+   * minimal /events?dataset=spans&where=[<just-this-filter>] navigation
+   * so the click still produces something useful.
+   */
+  fromHash?: string | null;
+  /**
+   * Originating /events tab — restored on the merged navigation so the
+   * user lands back where they came from. The tab isn't part of the
+   * stored Query AST (UI-only state), so it rides through the trace URL
+   * as its own search param. Defaults to "explore" when absent — the
+   * dataset-agnostic raw-rows view, which is where trace links live for
+   * spans/logs anyway.
+   */
+  fromTab?: "overview" | "traces" | "explore" | "tail" | null;
 }
 
 /**
@@ -42,6 +67,8 @@ export function SpanDetail({
   onSelectEvent,
   activeTab,
   onTabChange,
+  fromHash = null,
+  fromTab = null,
 }: Props) {
   const [localTab, setLocalTab] = useState("fields");
   const tab = activeTab ?? localTab;
@@ -49,6 +76,47 @@ export function SpanDetail({
     if (onTabChange) onTabChange(t);
     else setLocalTab(t);
   };
+
+  const navigate = useNavigate();
+  const onFilter = useCallback(
+    async (f: Filter) => {
+      // Restore the source tab so the user lands back where they
+      // clicked from. queryToUrlSearch can't recover this (tab is
+      // UI-only state, not in the Query AST), so the tab rides the
+      // trace URL alongside fromHash. Default to "explore" — that's
+      // where trace links physically live, so it's the right guess
+      // when fromTab is missing (deep-link, older session, etc).
+      const tab = fromTab ?? "explore";
+      // Best-effort recovery of the source query. We can't await
+      // user-perceived latency here, but a single indexed sqlite
+      // lookup is sub-ms in practice.
+      let merged: Record<string, unknown>;
+      if (fromHash) {
+        try {
+          const entry = await api.getHistoryByHash(fromHash);
+          const src = JSON.parse(entry.query_json) as Query;
+          const url = queryToUrlSearch(src);
+          merged = {
+            ...url,
+            where: appendWhere(url.where, f),
+            tab,
+          } as unknown as Record<string, unknown>;
+        } catch (err) {
+          // 404: row was pruned mid-flight. Anything else: log and
+          // fall through to the same minimal fallback. Either way the
+          // user gets a meaningful click result.
+          if (!(err instanceof HttpError) || err.status !== 404) {
+            console.warn("filter-by: history lookup failed", err);
+          }
+          merged = { dataset: "spans", where: [f], tab } as unknown as Record<string, unknown>;
+        }
+      } else {
+        merged = { dataset: "spans", where: [f], tab } as unknown as Record<string, unknown>;
+      }
+      navigate({ to: "/events", search: merged });
+    },
+    [fromHash, fromTab, navigate],
+  );
 
   if (!span) {
     return (
@@ -92,13 +160,14 @@ export function SpanDetail({
           <Tab value="links">Links ({span.links?.length ?? 0})</Tab>
         </Tabs.List>
         <Tabs.Content value="fields" className="flex-1 overflow-auto">
-          <AttributesPanel rows={allFields} />
+          <AttributesPanel rows={allFields} onFilter={onFilter} />
         </Tabs.Content>
         <Tabs.Content value="events" className="flex-1 overflow-auto">
           <EventsTab
             span={span}
             selectedIdx={selectedEventIdx}
             onSelect={onSelectEvent}
+            onFilter={onFilter}
           />
         </Tabs.Content>
         <Tabs.Content value="links" className="flex-1 overflow-auto">
@@ -224,10 +293,12 @@ function EventsTab({
   span,
   selectedIdx,
   onSelect,
+  onFilter,
 }: {
   span: SpanOut;
   selectedIdx: number | null;
   onSelect?: (idx: number | null) => void;
+  onFilter?: (filter: Filter) => void;
 }) {
   // Fallback local state when the parent doesn't want to own this.
   const [localIdx, setLocalIdx] = useState<number | null>(null);
@@ -261,6 +332,7 @@ function EventsTab({
         span={span}
         indexLabel={`${effectiveIdx + 1} / ${events.length}`}
         onBack={() => setIdx(null)}
+        onFilter={onFilter}
       />
     );
   }
@@ -307,11 +379,13 @@ function EventDetail({
   span,
   indexLabel,
   onBack,
+  onFilter,
 }: {
   event: NonNullable<SpanOut["events"]>[number];
   span: SpanOut;
   indexLabel: string;
   onBack: () => void;
+  onFilter?: (filter: Filter) => void;
 }) {
   const rows = useMemo(() => {
     // Synthesise meta rows alongside the user-set attributes so the whole
@@ -364,7 +438,7 @@ function EventDetail({
         </div>
       </div>
       <div className="flex-1 overflow-auto">
-        <AttributesPanel rows={rows} />
+        <AttributesPanel rows={rows} onFilter={onFilter} />
       </div>
     </div>
   );

--- a/ui/src/features/traces/TraceView.tsx
+++ b/ui/src/features/traces/TraceView.tsx
@@ -18,15 +18,36 @@ import { SpanDetail } from "./SpanDetail";
 import { WaterfallToolbar } from "./WaterfallToolbar";
 import { TraceSummary } from "./TraceSummary";
 
+/** Tab IDs that round-trip through the trace URL — kept in sync with
+ *  ResultTabs' TabID and querySearchSchema.tab. Passed through filter-by
+ *  so the user lands back on the tab they clicked from. */
+type FromTab = "overview" | "traces" | "explore" | "tail";
+
 interface Props {
   traceID: string;
   /** When set, once the trace loads we select this span, scroll it into
    *  view, and uncollapse its ancestors. Used for deep links from log
    *  rows ("?span=<id>"). */
   initialSpanID?: string | null;
+  /**
+   * Hex content-hash of the /events query the user came from. Threaded
+   * down to SpanDetail so the "filter by" button can fetch the
+   * originating QuerySearch from /api/history/<hash>, merge in the new
+   * filter, and navigate back. Null when the trace was deep-linked from
+   * outside.
+   */
+  fromHash?: string | null;
+  /** Originating /events tab. UI-only state, not in the Query AST, so
+   *  it rides alongside fromHash through the trace URL. */
+  fromTab?: FromTab | null;
 }
 
-export function TraceView({ traceID, initialSpanID = null }: Props) {
+export function TraceView({
+  traceID,
+  initialSpanID = null,
+  fromHash = null,
+  fromTab = null,
+}: Props) {
   const query = useQuery({
     queryKey: ["trace", traceID],
     queryFn: ({ signal }) => api.getTrace(traceID, signal),
@@ -268,6 +289,8 @@ export function TraceView({ traceID, initialSpanID = null }: Props) {
             onSelectEvent={setSelectedEventIdx}
             activeTab={activeTab}
             onTabChange={setActiveTab}
+            fromHash={fromHash}
+            fromTab={fromTab}
           />
         </div>
       </div>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -138,6 +138,12 @@ export const api = {
       `/api/history?limit=${limit}`,
       signal,
     ),
+
+  // Look up a single dedup'd query_history entry by its hex content
+  // hash. Throws HttpError(404) when the row was pruned out — callers
+  // can branch on `err.status === 404` to fall back gracefully.
+  getHistoryByHash: (hash: string, signal?: AbortSignal) =>
+    getJSON<QueryHistoryEntry>(`/api/history/${hash}`, signal),
 };
 
 export interface QueryHistoryEntry {

--- a/ui/src/lib/query.ts
+++ b/ui/src/lib/query.ts
@@ -117,6 +117,13 @@ export interface QueryResult {
   rows: unknown[][];
   has_bucket: boolean;
   group_keys?: string[];
+  /**
+   * Hex SHA-256 of the canonicalized query AST. Server-set when the run
+   * was recorded in query_history (i.e. when the request had a non-empty
+   * SELECT). Threaded as ?from=<hash> on trace links so the trace view
+   * can recover the originating query for "filter by".
+   */
+  history_hash?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -565,6 +572,31 @@ export function summarizeOrderBy(o: Order[]): string {
  * active tab in history). Returns a partial suitable for TanStack
  * Router's search param.
  */
+/**
+ * Append `next` to `existing`, skipping if a filter with the same
+ * (field, op, value) is already present. Used by the "filter by"
+ * affordance on attribute panels: clicking the same value twice
+ * shouldn't pile up duplicates, but distinct values on the same field
+ * are appended (they form an AND — possibly unsatisfiable, which the
+ * user can fix in the WhereEditor; silent rewriting is worse).
+ */
+export function appendWhere(existing: Filter[] | undefined, next: Filter): Filter[] {
+  const list = existing ?? [];
+  const isDup = list.some(
+    (f) => f.field === next.field && f.op === next.op && filterValueEq(f.value, next.value),
+  );
+  return isDup ? list : [...list, next];
+}
+
+function filterValueEq(a: Filter["value"], b: Filter["value"]): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
+  return a === b;
+}
+
 export function queryToUrlSearch(q: Query): Partial<QuerySearch> {
   const fromMs = q.time_range?.from ? new Date(q.time_range.from).getTime() : undefined;
   const toMs = q.time_range?.to ? new Date(q.time_range.to).getTime() : undefined;

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -11,11 +11,26 @@ import { HistoryPage } from "./routes/HistoryPage";
 import { TraceView } from "./features/traces/TraceView";
 import { querySearchSchema } from "./lib/query";
 
-// Trace route accepts an optional ?span=<id> to deep-link into a specific
-// span — e.g. clicking the trace link on a log row opens the waterfall
-// with that log's emitting span pre-selected and scrolled into view.
+// Trace route accepts:
+//   ?span=<id>   — deep-link into a specific span (clicking a log row's
+//                  trace link pre-selects the emitting span).
+//   ?from=<hex>  — content-hash of the originating /events query
+//                  (query_history). The "filter by" affordance on span
+//                  attributes uses this to round-trip back to the source
+//                  query with the new filter merged in. 64-char lower
+//                  hex (SHA-256). Optional — deep-links from outside
+//                  (e.g. shared trace URLs) just don't have it, and the
+//                  filter button falls back to a default /events view.
+//   ?tab=<id>    — originating /events tab (Overview/Traces/Explore/
+//                  Tail). Round-tripped purely so filter-by lands the
+//                  user back on the same tab they clicked from. The
+//                  tab isn't part of the Query AST stored in
+//                  query_history, so we pass it alongside `from`
+//                  rather than inside it.
 const traceDetailSearchSchema = z.object({
   span: z.string().optional(),
+  from: z.string().regex(/^[0-9a-f]{64}$/).optional(),
+  tab: z.enum(["overview", "traces", "explore", "tail"]).optional(),
 });
 
 const rootRoute = createRootRoute({
@@ -72,8 +87,15 @@ const traceDetailRoute = createRoute({
   validateSearch: traceDetailSearchSchema,
   component: function TraceDetailRoute() {
     const { traceId } = traceDetailRoute.useParams();
-    const { span } = traceDetailRoute.useSearch();
-    return <TraceView traceID={traceId} initialSpanID={span ?? null} />;
+    const { span, from, tab } = traceDetailRoute.useSearch();
+    return (
+      <TraceView
+        traceID={traceId}
+        initialSpanID={span ?? null}
+        fromHash={from ?? null}
+        fromTab={tab ?? null}
+      />
+    );
   },
 });
 

--- a/ui/src/routes/EventsPage.tsx
+++ b/ui/src/routes/EventsPage.tsx
@@ -17,11 +17,13 @@ import {
   type SelectedRow,
 } from "../features/query/EventsTable";
 import {
+  appendWhere,
   bucketMsFor,
   buildCountQuery,
   refreshIntervalMs,
   resolveSearchRange,
   runQuery,
+  type Filter,
   type QueryResult,
   type QuerySearch,
 } from "../lib/query";
@@ -146,6 +148,29 @@ export function EventsPage() {
     enabled: committedSearch.dataset !== "metrics" || hasMetricField(committedSearch),
   });
 
+  // Hex content-hash of the most recent successful chart run. Threaded
+  // into trace links as ?from=<hash> so the trace view's "filter by"
+  // affordance can recover the originating query and merge in a new
+  // WHERE clause. Cleared while a fresh query is in flight so we never
+  // attribute a click to a stale source query.
+  const historyHash = chart.data?.history_hash ?? null;
+
+  // In-page "filter by" — fired from the log/metric detail pane's
+  // AttributesPanel. Same dedup-and-append semantics as the trace view's
+  // cross-route version, but no fetch needed since the source query is
+  // already on screen. Sets both `search` (URL) and `committedSearch`
+  // (active query) and bumps runCount so the chart + table refetch
+  // immediately, mirroring the Run button's behaviour.
+  const applyInPageFilter = (f: Filter) => {
+    const next: QuerySearch = {
+      ...search,
+      where: appendWhere(search.where, f),
+    };
+    setSearch(next);
+    setCommittedSearch(next);
+    setRunCount((c) => c + 1);
+  };
+
   const resolved = resolveSearchRange(search);
   const handleBucketClick = (tMs: number) => {
     const bucketMs = bucketMsFor(resolved.durationMs, search.granularity);
@@ -227,6 +252,7 @@ export function EventsPage() {
             search={search}
             querySearch={committedSearch}
             runCount={runCount}
+            historyHash={historyHash}
             onTabChange={(tab) => setSearch({ ...search, tab })}
             onExploreScrollY={handleExploreScrollY}
             selectedRow={detailPaneEligible ? selectedRow : null}
@@ -247,12 +273,16 @@ export function EventsPage() {
               columns={pane.columns}
               row={pane.row}
               onClose={() => setSelectedRow(null)}
+              onFilter={applyInPageFilter}
+              historyHash={historyHash}
+              currentTab={search.tab}
             />
           ) : (
             <MetricDetailPane
               columns={pane.columns}
               row={pane.row}
               onClose={() => setSelectedRow(null)}
+              onFilter={applyInPageFilter}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- Span-attribute filter button now navigates to `/events` with the originating query restored and the new filter appended to `WHERE`. Previously it dropped you on a default `/events` with everything else lost.
- Originating query identified by its `query_history` content hash, threaded through the trace URL as `?from=<hex>`. `POST /api/query` now returns the hash on the response; new `GET /api/history/{hash}` endpoint recovers the source `Query` AST.
- Active tab rides the trace URL too (`?tab=...`) so the user lands back on the tab they came from rather than reverting to Overview.
- Filters dedupe on `(field, op, value)` so repeat clicks don't pile up duplicates. Same merge-and-rerun semantics now also fix the in-page log/metric detail panes (which previously overwrote `WHERE`).

## Test plan
- [x] `go test ./...` — new `TestAPI_HistoryByHash` covers happy path, malformed hex (400), short hex (400), unknown hash (404).
- [x] `npm run build` (tsc + vite).
- [ ] Manual: on `/events` with a non-empty WHERE, click into a trace, click the filter icon on a span attribute → should land back on `/events` with the original WHERE + new filter appended, on the same tab.
- [ ] Manual: click the same filter twice → no duplicate filter row (dedupe).
- [ ] Manual: open a trace URL directly (no `?from`) → filter-by falls back to `/events?dataset=spans&where=[…]&tab=explore`.
- [ ] Manual: log dataset, open detail pane, click filter on an attribute → URL `WHERE` extends and chart re-runs without leaving the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)