### PR TITLE
fix: make the service list dataset-aware

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -138,7 +138,7 @@ func (rt *Router) listHistory(w http.ResponseWriter, r *http.Request) {
 }
 
 func (rt *Router) listServices(w http.ResponseWriter, r *http.Request) {
-	svcs, err := rt.store.ListServices(r.Context())
+	svcs, err := rt.store.ListServices(r.Context(), r.URL.Query().Get("dataset"))
 	if err != nil {
 		rt.writeError(w, err)
 		return

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -215,8 +215,8 @@ func TestAPI_Services(t *testing.T) {
 	if populated.Services[0].ServiceName != "widget" {
 		t.Errorf("service name: %q", populated.Services[0].ServiceName)
 	}
-	if populated.Services[0].SpanCount != 2 {
-		t.Errorf("span count: %d", populated.Services[0].SpanCount)
+	if populated.Services[0].EventCount != 2 {
+		t.Errorf("event count: %d", populated.Services[0].EventCount)
 	}
 	if populated.Services[0].ErrorCount != 1 {
 		t.Errorf("error count: %d", populated.Services[0].ErrorCount)

--- a/internal/ingest/e2e_fixture_test.go
+++ b/internal/ingest/e2e_fixture_test.go
@@ -183,12 +183,12 @@ func (f *e2eFixture) shutdownLogger(lp *sdklog.LoggerProvider) {
 func (f *e2eFixture) waitForSpanCount(svc string, n int) {
 	f.t.Helper()
 	waitFor(f.t, 3*time.Second, fmt.Sprintf("spans for %q >= %d", svc, n), func() bool {
-		services, err := f.st.ListServices(f.ctx)
+		services, err := f.st.ListServices(f.ctx, "spans")
 		if err != nil {
 			return false
 		}
 		for _, s := range services {
-			if s.ServiceName == svc && s.SpanCount >= int64(n) {
+			if s.ServiceName == svc && s.EventCount >= int64(n) {
 				return true
 			}
 		}
@@ -201,13 +201,13 @@ func (f *e2eFixture) waitForSpanCount(svc string, n int) {
 func (f *e2eFixture) waitForTotalSpanCount(n int) {
 	f.t.Helper()
 	waitFor(f.t, 3*time.Second, fmt.Sprintf("total spans >= %d", n), func() bool {
-		services, err := f.st.ListServices(f.ctx)
+		services, err := f.st.ListServices(f.ctx, "spans")
 		if err != nil {
 			return false
 		}
 		var total int64
 		for _, s := range services {
-			total += s.SpanCount
+			total += s.EventCount
 		}
 		return total >= int64(n)
 	})

--- a/internal/ingest/e2e_ops_test.go
+++ b/internal/ingest/e2e_ops_test.go
@@ -116,8 +116,8 @@ func TestE2E_Retention(t *testing.T) {
 
 	var svcResp struct {
 		Services []struct {
-			Service   string `json:"service"`
-			SpanCount int64  `json:"span_count"`
+			Service    string `json:"service"`
+			EventCount int64  `json:"event_count"`
 		} `json:"services"`
 	}
 	if err := f.getJSON("/api/services", &svcResp); err != nil {
@@ -126,11 +126,11 @@ func TestE2E_Retention(t *testing.T) {
 	var svcCount int64
 	for _, s := range svcResp.Services {
 		if s.Service == "retain-svc" {
-			svcCount = s.SpanCount
+			svcCount = s.EventCount
 		}
 	}
 	if svcCount != 3 {
-		t.Errorf("retain-svc span_count after cutoff: want 3 (new), got %d", svcCount)
+		t.Errorf("retain-svc event_count after cutoff: want 3 (new), got %d", svcCount)
 	}
 }
 

--- a/internal/ingest/e2e_spans_test.go
+++ b/internal/ingest/e2e_spans_test.go
@@ -474,11 +474,11 @@ func TestE2E_CrossServiceTrace(t *testing.T) {
 		t.Errorf("payments span missing / wrong: %v", got)
 	}
 
-	// Service list must show both with span_count = 1 each.
+	// Service list must show both with event_count = 1 each.
 	var svcResp struct {
 		Services []struct {
-			Service   string `json:"service"`
-			SpanCount int64  `json:"span_count"`
+			Service    string `json:"service"`
+			EventCount int64  `json:"event_count"`
 		} `json:"services"`
 	}
 	if err := f.getJSON("/api/services", &svcResp); err != nil {
@@ -486,7 +486,7 @@ func TestE2E_CrossServiceTrace(t *testing.T) {
 	}
 	per := map[string]int64{}
 	for _, s := range svcResp.Services {
-		per[s.Service] = s.SpanCount
+		per[s.Service] = s.EventCount
 	}
 	if per["gateway"] != 1 || per["payments"] != 1 {
 		t.Errorf("service counts want gateway=1 payments=1, got %v", per)

--- a/internal/ingest/sdk_grpc_integration_test.go
+++ b/internal/ingest/sdk_grpc_integration_test.go
@@ -147,12 +147,12 @@ func TestSDK_GRPC_TracesRoundTrip(t *testing.T) {
 	}
 
 	waitFor(t, 3*time.Second, "service row with 2 spans", func() bool {
-		svcs, err := f.st.ListServices(f.ctx)
+		svcs, err := f.st.ListServices(f.ctx, "spans")
 		if err != nil {
 			return false
 		}
 		for _, s := range svcs {
-			if s.ServiceName == "sdk-grpc-trace-test" && s.SpanCount == 2 {
+			if s.ServiceName == "sdk-grpc-trace-test" && s.EventCount == 2 {
 				return true
 			}
 		}

--- a/internal/ingest/sdk_integration_test.go
+++ b/internal/ingest/sdk_integration_test.go
@@ -163,12 +163,12 @@ func TestSDK_TracesRoundTrip(t *testing.T) {
 	}
 
 	waitFor(t, 3*time.Second, "service row with 3 spans", func() bool {
-		svcs, err := f.st.ListServices(f.ctx)
+		svcs, err := f.st.ListServices(f.ctx, "spans")
 		if err != nil {
 			return false
 		}
 		for _, s := range svcs {
-			if s.ServiceName == "sdk-int-test" && s.SpanCount == 3 {
+			if s.ServiceName == "sdk-int-test" && s.EventCount == 3 {
 				return true
 			}
 		}

--- a/internal/ingest/sdk_varied_test.go
+++ b/internal/ingest/sdk_varied_test.go
@@ -101,20 +101,20 @@ func TestSDK_TracesVariedAttributes(t *testing.T) {
 	// --- wait for ingest to settle ------------------------------------------
 
 	waitFor(t, 5*time.Second, "50 spans across 3 services", func() bool {
-		svcs, err := f.st.ListServices(f.ctx)
+		svcs, err := f.st.ListServices(f.ctx, "spans")
 		if err != nil {
 			return false
 		}
 		byName := map[string]int64{}
 		for _, s := range svcs {
-			byName[s.ServiceName] = s.SpanCount
+			byName[s.ServiceName] = s.EventCount
 		}
 		return byName["api-gateway"] == 20 && byName["payments"] == 15 && byName["db-worker"] == 15
 	})
 
 	// --- services + error rates ---------------------------------------------
 
-	svcs, err := f.st.ListServices(f.ctx)
+	svcs, err := f.st.ListServices(f.ctx, "spans")
 	if err != nil {
 		t.Fatalf("ListServices: %v", err)
 	}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -53,7 +53,7 @@ type timeRange struct {
 func registerTools(s *mcp.Server, t *tools) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_services",
-		Description: "List services that have reported spans, with span and error counts. Use this first to discover what is being observed.",
+		Description: "List services that have data in a dataset (default spans), with row and error counts. Pass dataset=logs or dataset=metrics to discover services that only emit those signals. Use this first to discover what is being observed.",
 	}, t.listServices)
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -103,12 +103,16 @@ func registerTools(s *mcp.Server, t *tools) {
 
 // ---- list_services ----------------------------------------------------------
 
+type servicesInput struct {
+	Dataset string `json:"dataset,omitempty" jsonschema:"one of spans, logs, metrics (default spans)"`
+}
+
 type servicesOutput struct {
 	Services []store.ServiceSummary `json:"services"`
 }
 
-func (t *tools) listServices(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, servicesOutput, error) {
-	svcs, err := t.store.ListServices(ctx)
+func (t *tools) listServices(ctx context.Context, _ *mcp.CallToolRequest, in servicesInput) (*mcp.CallToolResult, servicesOutput, error) {
+	svcs, err := t.store.ListServices(ctx, in.Dataset)
 	if err != nil {
 		return nil, servicesOutput{}, fmt.Errorf("list services: %w", err)
 	}

--- a/internal/mcpserver/tools_test.go
+++ b/internal/mcpserver/tools_test.go
@@ -222,7 +222,7 @@ func TestQueryToolInvalidDataset(t *testing.T) {
 
 func TestListServicesTool(t *testing.T) {
 	tl := newSeededTools(t)
-	_, out, err := tl.listServices(context.Background(), nil, struct{}{})
+	_, out, err := tl.listServices(context.Background(), nil, servicesInput{})
 	if err != nil {
 		t.Fatalf("listServices: %v", err)
 	}

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -147,10 +147,13 @@ type Batch struct {
 	MetaOverwrites int64
 }
 
-// ServiceSummary is a row for the service/dataset selector.
+// ServiceSummary is a row for the service/dataset selector. EventCount is the
+// number of rows the service has in the queried dataset (spans, logs, or
+// metric events); ErrorCount/ErrorRate are span-only and stay zero for the
+// log and metric datasets.
 type ServiceSummary struct {
 	ServiceName string  `json:"service"`
-	SpanCount   int64   `json:"span_count"`
+	EventCount  int64   `json:"event_count"`
 	ErrorCount  int64   `json:"error_count"`
 	ErrorRate   float64 `json:"error_rate"`
 }

--- a/internal/store/sqlite/queries.go
+++ b/internal/store/sqlite/queries.go
@@ -276,12 +276,29 @@ func writeAttrValues(ctx context.Context, tx *sql.Tx, vs []store.AttrValueDelta)
 // Read paths
 // =========================================================================
 
-func (s *Store) ListServices(ctx context.Context) ([]store.ServiceSummary, error) {
-	const q = `SELECT service_name,
-		COUNT(*) AS total,
-		SUM(CASE WHEN status_code = 2 THEN 1 ELSE 0 END) AS errs
-		FROM events WHERE signal_type = 'span'
-		GROUP BY service_name ORDER BY total DESC`
+func (s *Store) ListServices(ctx context.Context, dataset string) ([]store.ServiceSummary, error) {
+	// Spans and logs live in events (keyed by signal_type); metrics live in
+	// metric_events. Errors are a span concept, so only the spans dataset
+	// computes a non-zero error count. service_name is always set from the
+	// resource, but guard against NULL so a malformed row can't surface as a
+	// blank, unselectable entry.
+	var q string
+	switch dataset {
+	case "logs":
+		q = `SELECT service_name, COUNT(*) AS total, 0 AS errs
+			FROM events WHERE signal_type = 'log' AND service_name IS NOT NULL
+			GROUP BY service_name ORDER BY total DESC`
+	case "metrics":
+		q = `SELECT service_name, COUNT(*) AS total, 0 AS errs
+			FROM metric_events WHERE service_name IS NOT NULL
+			GROUP BY service_name ORDER BY total DESC`
+	default: // spans
+		q = `SELECT service_name,
+			COUNT(*) AS total,
+			SUM(CASE WHEN status_code = 2 THEN 1 ELSE 0 END) AS errs
+			FROM events WHERE signal_type = 'span' AND service_name IS NOT NULL
+			GROUP BY service_name ORDER BY total DESC`
+	}
 	rows, err := s.reader.QueryContext(ctx, q)
 	if err != nil {
 		return nil, err
@@ -290,11 +307,11 @@ func (s *Store) ListServices(ctx context.Context) ([]store.ServiceSummary, error
 	var out []store.ServiceSummary
 	for rows.Next() {
 		var r store.ServiceSummary
-		if err := rows.Scan(&r.ServiceName, &r.SpanCount, &r.ErrorCount); err != nil {
+		if err := rows.Scan(&r.ServiceName, &r.EventCount, &r.ErrorCount); err != nil {
 			return nil, err
 		}
-		if r.SpanCount > 0 {
-			r.ErrorRate = float64(r.ErrorCount) / float64(r.SpanCount)
+		if r.EventCount > 0 {
+			r.ErrorRate = float64(r.ErrorCount) / float64(r.EventCount)
 		}
 		out = append(out, r)
 	}

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -67,11 +67,11 @@ func TestWriteAndReadSpan(t *testing.T) {
 		t.Fatalf("WriteBatch: %v", err)
 	}
 
-	services, err := s.ListServices(ctx)
+	services, err := s.ListServices(ctx, "spans")
 	if err != nil {
 		t.Fatalf("ListServices: %v", err)
 	}
-	if len(services) != 1 || services[0].ServiceName != "test" || services[0].SpanCount != 1 {
+	if len(services) != 1 || services[0].ServiceName != "test" || services[0].EventCount != 1 {
 		t.Fatalf("unexpected services: %+v", services)
 	}
 
@@ -170,4 +170,67 @@ func TestPercentileUDF(t *testing.T) {
 	if p95 < 9.0 || p95 > 10.0 {
 		t.Errorf("p95 expected ~9.5, got %v", p95)
 	}
+}
+
+// TestListServicesByDataset is the regression guard for the bug where
+// ListServices was span-only: a service that emits only logs or only metrics
+// must appear under its own dataset and not under spans.
+func TestListServicesByDataset(t *testing.T) {
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	now := time.Now().UnixNano()
+	tid := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	sid := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	end := now + 1_000_000
+	ok := int32(0)
+	var flags uint32
+
+	batch := store.Batch{
+		Resources: []store.Resource{
+			{ID: 1, ServiceName: "spanner", FirstSeenNS: now, LastSeenNS: now},
+			{ID: 2, ServiceName: "logger", FirstSeenNS: now, LastSeenNS: now},
+			{ID: 3, ServiceName: "metricer", FirstSeenNS: now, LastSeenNS: now},
+		},
+		Scopes: []store.Scope{{ID: 1, Name: "go.test", Version: "v1"}},
+		Events: []store.Event{
+			{
+				TimeNS: now, EndTimeNS: &end, ResourceID: 1, ScopeID: 1,
+				ServiceName: "spanner", Name: "op", TraceID: tid, SpanID: sid,
+				StatusCode: &ok, Flags: &flags,
+				AttributesJSON: `{"meta.signal_type":"span"}`,
+			},
+			{
+				TimeNS: now, ResourceID: 2, ScopeID: 1,
+				ServiceName: "logger", Name: "log", Body: "hello",
+				AttributesJSON: `{"meta.signal_type":"log"}`,
+			},
+		},
+		MetricEvents: []store.MetricEvent{{
+			TimeNS: now, ResourceID: 3, ScopeID: 1, ServiceName: "metricer",
+			AttributesJSON: `{"meta.signal_type":"metric","requests.total":1}`,
+		}},
+	}
+	if err := s.WriteBatch(ctx, batch); err != nil {
+		t.Fatalf("WriteBatch: %v", err)
+	}
+
+	only := func(dataset, want string) {
+		t.Helper()
+		svcs, err := s.ListServices(ctx, dataset)
+		if err != nil {
+			t.Fatalf("ListServices(%q): %v", dataset, err)
+		}
+		if len(svcs) != 1 || svcs[0].ServiceName != want || svcs[0].EventCount != 1 {
+			t.Fatalf("ListServices(%q) = %+v, want only %q with EventCount 1", dataset, svcs, want)
+		}
+	}
+	only("spans", "spanner")
+	only("logs", "logger")
+	only("metrics", "metricer")
+	only("", "spanner") // empty defaults to spans
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,7 +53,10 @@ type ValueFilter struct {
 type Store interface {
 	WriteBatch(ctx context.Context, b Batch) error
 
-	ListServices(ctx context.Context) ([]ServiceSummary, error)
+	// ListServices lists services that have data in the given dataset
+	// ("spans", "logs", or "metrics"); an empty/unknown dataset defaults to
+	// spans. EventCount reflects that dataset's row count per service.
+	ListServices(ctx context.Context, dataset string) ([]ServiceSummary, error)
 	ListTraces(ctx context.Context, f TraceFilter) ([]TraceSummary, string, error)
 	GetTrace(ctx context.Context, traceID string) (TraceDetail, error)
 

--- a/ui/src/features/query/DefinePanel.tsx
+++ b/ui/src/features/query/DefinePanel.tsx
@@ -71,6 +71,7 @@ export function DefinePanel({ dataset, search, onChange, onDatasetChange, onRun,
           />
           <span style={{ color: "var(--color-ink-muted)" }}>·</span>
           <ServicePicker
+            dataset={dataset}
             where={search.where}
             onChange={(where) => onChange({ ...search, where })}
           />

--- a/ui/src/features/query/ServicePicker.tsx
+++ b/ui/src/features/query/ServicePicker.tsx
@@ -1,11 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDown } from "lucide-react";
 import { api, type ServiceSummary } from "../../lib/api";
-import type { Filter } from "../../lib/query";
+import type { Dataset, Filter } from "../../lib/query";
 import { serviceColor } from "../../lib/colors";
 import { Popover } from "../../components/ui/Popover";
 
 interface Props {
+  /** Dataset to list services for — counts and membership are per-signal. */
+  dataset: Dataset;
   /** Current WHERE list — picker reads/writes the service.name = filter within. */
   where: Filter[];
   onChange: (next: Filter[]) => void;
@@ -17,10 +19,10 @@ interface Props {
  * switching between logical groupings of data. Under the hood it just
  * mutates a service.name = "<name>" equality filter in the WHERE list.
  */
-export function ServicePicker({ where, onChange }: Props) {
+export function ServicePicker({ dataset, where, onChange }: Props) {
   const services = useQuery({
-    queryKey: ["services"],
-    queryFn: ({ signal }) => api.listServices(signal),
+    queryKey: ["services", dataset],
+    queryFn: ({ signal }) => api.listServices(dataset, signal),
     staleTime: 30_000,
   });
 
@@ -99,7 +101,7 @@ export function ServicePicker({ where, onChange }: Props) {
               className="text-xs tabular-nums"
               style={{ color: "var(--color-ink-muted)" }}
             >
-              {s.span_count.toLocaleString()}
+              {s.event_count.toLocaleString()}
             </span>
           </button>
         ))}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -2,7 +2,7 @@
 
 export interface ServiceSummary {
   service: string;
-  span_count: number;
+  event_count: number;
   error_count: number;
   error_rate: number;
 }
@@ -103,8 +103,11 @@ async function getJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
 }
 
 export const api = {
-  listServices: (signal?: AbortSignal) =>
-    getJSON<{ services: ServiceSummary[] }>("/api/services", signal),
+  listServices: (dataset: string, signal?: AbortSignal) =>
+    getJSON<{ services: ServiceSummary[] }>(
+      `/api/services?dataset=${encodeURIComponent(dataset)}`,
+      signal,
+    ),
 
   listTraces: (params: URLSearchParams, signal?: AbortSignal) =>
     getJSON<{ traces: TraceSummary[]; next_cursor: string }>(


### PR DESCRIPTION
## Summary
`ListServices` was hardcoded to `signal_type = 'span'`, so a service that emits **only logs or only metrics** (e.g. `claude-code`) never showed up in the UI's service picker — even though its data was queryable and visible in the metrics/logs tables. [Reported with a screenshot: picker shows only `event-router` while the metrics table is full of `claude-code` rows.]

## Changes
- **`ListServices(ctx, dataset)`** — spans and logs read from `events` by `signal_type`; metrics read from `metric_events`. Empty/unknown dataset defaults to spans. Errors remain a span-only concept (zero for logs/metrics).
- **`GET /api/services?dataset=`** — the endpoint reads the dataset param (default spans).
- **UI service picker is dataset-aware** — `ServicePicker` takes the current dataset, keys its react-query cache by it, and renders the per-dataset count. So in `metrics` you see services with metrics; in `spans` you see `event-router` with its span count.
- **`ServiceSummary.span_count` → `event_count`** (Go + TS) — the badge is no longer span-specific. `error_count`/`error_rate` stay span-derived.
- **MCP `list_services`** gains an optional `dataset` for the same reason.

## Tests
- [x] New `TestListServicesByDataset` — a spans-only, a logs-only, and a metrics-only service each appear under (only) their dataset; empty defaults to spans.
- [x] Updated all existing callers (ingest e2e + store + api tests) for the new signature and `event_count` rename.
- [x] `go vet`, full `go test ./...`, `gofmt`, and `tsc --noEmit` all clean.

## Note
UI was typechecked but not browser-verified in this run — the change is a prop + query-key + field rename. Worth an eyeball after rebuilding the embedded UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)