### PR TITLE
fix(ui): smarter filter-editor input and single-clickable chips

### DIFF
--- a/ui/src/features/query/FilterChip.tsx
+++ b/ui/src/features/query/FilterChip.tsx
@@ -1,7 +1,7 @@
+import { useState } from "react";
 import { X } from "lucide-react";
 import type { Dataset, Filter } from "../../lib/query";
 import { filterToText } from "../../lib/filterText";
-import { Popover } from "../../components/ui/Popover";
 import { FilterInput } from "./FilterInput";
 
 interface Props {
@@ -15,11 +15,32 @@ interface Props {
 const OPS_WITHOUT_VALUE = new Set(["exists", "!exists"]);
 
 /**
- * Compact chip for a single committed filter. Clicking the field opens the
- * free-form FilterInput prefilled with this filter's text, so editing uses
- * the same autocomplete pathway as adding a new filter.
+ * A single committed filter. The whole `field op value` reads as one
+ * clickable entity: clicking it drops back into the free-form FilterInput
+ * (prefilled with this filter's text) so the field, operator, and value are
+ * all editable as one string via the same autocomplete pathway used to add a
+ * filter. Enter re-commits it to a chip; Escape cancels.
  */
 export function FilterChip({ filter, dataset = "spans", service, onChange, onRemove }: Props) {
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <div style={{ minWidth: 360 }}>
+        <FilterInput
+          dataset={dataset}
+          service={service}
+          initial={filterToText(filter)}
+          onSubmit={(f) => {
+            onChange(f);
+            setEditing(false);
+          }}
+          onCancel={() => setEditing(false)}
+        />
+      </div>
+    );
+  }
+
   return (
     <div
       className="flex items-center rounded-md border text-sm overflow-hidden"
@@ -28,36 +49,18 @@ export function FilterChip({ filter, dataset = "spans", service, onChange, onRem
         borderColor: "var(--color-border)",
       }}
     >
-      <Popover
-        trigger={
-          <button
-            type="button"
-            className="px-2 py-1 font-mono hover:bg-[var(--color-card-hover)]"
-          >
-            {filter.field}
-          </button>
-        }
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className="flex items-center gap-1.5 px-2 py-1 font-mono min-w-0 hover:bg-[var(--color-card-hover)]"
+        title="Click to edit"
       >
-        <div style={{ minWidth: 360 }}>
-          <FilterInput
-            dataset={dataset}
-            service={service}
-            initial={filterToText(filter)}
-            onSubmit={onChange}
-          />
-        </div>
-      </Popover>
-
-      <div
-        className="px-2 py-1"
-        style={{ color: "var(--color-ink-muted)", background: "var(--color-surface-muted)" }}
-      >
-        {filter.op}
-      </div>
-
-      {!OPS_WITHOUT_VALUE.has(filter.op) && (
-        <div className="px-2 py-1 font-mono truncate max-w-xs">{formatValue(filter.value)}</div>
-      )}
+        <span>{filter.field}</span>
+        <span style={{ color: "var(--color-ink-muted)" }}>{filter.op}</span>
+        {!OPS_WITHOUT_VALUE.has(filter.op) && (
+          <span className="truncate max-w-xs">{formatValue(filter.value)}</span>
+        )}
+      </button>
 
       <button
         type="button"

--- a/ui/src/features/query/FilterChip.tsx
+++ b/ui/src/features/query/FilterChip.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { X } from "lucide-react";
-import type { Dataset, Filter } from "../../lib/query";
+import { BOOLEAN_META_FIELDS, type Dataset, type Filter } from "../../lib/query";
 import { filterToText } from "../../lib/filterText";
 import { FilterInput } from "./FilterInput";
 
@@ -56,9 +56,16 @@ export function FilterChip({ filter, dataset = "spans", service, onChange, onRem
         title="Click to edit"
       >
         <span>{filter.field}</span>
-        <span style={{ color: "var(--color-ink-muted)" }}>{filter.op}</span>
-        {!OPS_WITHOUT_VALUE.has(filter.op) && (
-          <span className="truncate max-w-xs">{formatValue(filter.value)}</span>
+        {/* A boolean meta field committed as "= true" is shown bare — the
+            "= true" is implied by its presence, matching how filterToText
+            serializes it. "= false" and other ops still render in full. */}
+        {!isBareBool(filter) && (
+          <>
+            <span style={{ color: "var(--color-ink-muted)" }}>{filter.op}</span>
+            {!OPS_WITHOUT_VALUE.has(filter.op) && (
+              <span className="truncate max-w-xs">{formatValue(filter.value)}</span>
+            )}
+          </>
         )}
       </button>
 
@@ -72,6 +79,10 @@ export function FilterChip({ filter, dataset = "spans", service, onChange, onRem
       </button>
     </div>
   );
+}
+
+function isBareBool(f: Filter): boolean {
+  return f.op === "=" && f.value === true && BOOLEAN_META_FIELDS.has(f.field);
 }
 
 function formatValue(v: Filter["value"]): string {

--- a/ui/src/features/query/FilterInput.tsx
+++ b/ui/src/features/query/FilterInput.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api, type FieldInfo } from "../../lib/api";
-import type { Dataset, Filter } from "../../lib/query";
+import { BOOLEAN_META_FIELDS, type Dataset, type Filter } from "../../lib/query";
 import {
   applySuggestion,
   FILTER_OP_DISPLAY,
@@ -123,6 +123,20 @@ export function FilterInput({
   };
 
   const takeSuggestion = (s: Suggestion) => {
+    // A boolean field (is_root, error, or any bool-typed attribute) is a
+    // complete search on its own — selecting it commits "= true" straight
+    // away rather than dropping into the operator phase and making the user
+    // type "= true".
+    if (
+      parsed.phase === "field" &&
+      (s.hint === "bool" || BOOLEAN_META_FIELDS.has(s.value))
+    ) {
+      onSubmit({ field: s.value, op: "=", value: true });
+      setText("");
+      setSelected(0);
+      requestAnimationFrame(() => inputRef.current?.focus());
+      return;
+    }
     const next = applySuggestion(text, parsed, s.value);
     setText(next);
     setSelected(0);
@@ -151,13 +165,29 @@ export function FilterInput({
             takeSuggestion(suggestions[selected]);
           } else if (e.key === "Enter") {
             e.preventDefault();
-            // Enter commits when the text parses to a valid filter; otherwise
-            // accept the highlighted suggestion to keep the flow going.
-            const f = textToFilter(text);
-            if (f) {
-              commit();
-            } else if (suggestions.length > 0) {
-              takeSuggestion(suggestions[selected]);
+            const active =
+              suggestions.length > 0 ? suggestions[selected] : undefined;
+            // Mid-typing a field or value: accept the highlighted suggestion
+            // rather than committing the partial token. textToFilter treats a
+            // partial value like "db4" (or a partial field name) as a complete
+            // filter, so without this Enter would submit the half-typed token
+            // instead of the suggestion the dropdown is showing. takeSuggestion
+            // completes the token (or, for a boolean field, commits it). The
+            // operator phase is left out: there the partial is empty and the
+            // bare-field "exists"/"= true" commit must still win.
+            if (
+              (parsed.phase === "value" || parsed.phase === "field") &&
+              active &&
+              active.value !== parsed.partial
+            ) {
+              takeSuggestion(active);
+            } else {
+              const f = textToFilter(text);
+              if (f) {
+                commit();
+              } else if (suggestions.length > 0) {
+                takeSuggestion(suggestions[selected]);
+              }
             }
           } else if (e.key === "Escape") {
             e.preventDefault();


### PR DESCRIPTION
## Summary
Three related fixes to the WHERE/HAVING filter editor (`FilterInput` + `FilterChip`), all verified in a live browser against real `claude-code` metrics data.

### 1. Value completion on Enter
Pressing Enter while mid-typing a **value** now accepts the highlighted suggestion (the full value) instead of committing the partial text. `textToFilter` treats a partial like `db4` as a complete filter, so Enter was submitting the half-typed value rather than the one the dropdown was showing. The same now applies to field-name completion. (Multi-value-by-arrow already worked because an empty value parsed to `null`; this makes the single-suggestion / partial-typed case behave consistently.)

### 2. Boolean fields commit on select
Selecting a boolean field — `is_root`, `error`, or any `bool`-typed attribute — commits `= true` immediately, rather than dropping into the operator phase and forcing the user to type `= true`. A boolean meta field is a complete search on its own.

### 3. Single-clickable filter chips
A committed filter now reads as **one clickable entity**. Clicking it drops the whole `field op value` back into the free-form input as a single editable string; Enter re-commits it to a chip. Previously only the field opened an editor — you couldn't click the operator or value to change them without re-typing the field.

## Test plan (Playwright, against a snapshot of the running DB)
- [x] `organization.id = db4` (single value): Enter completes to the full UUID, second Enter commits it — no longer commits `db4`
- [x] `is_` + Enter → commits `is_root = true` directly
- [x] Click `is_root = true` chip → inline single-box editor → change to `= false` → Enter → re-commits as `is_root = false`
- [x] `tsc --noEmit` clean; `go tool task build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)