### PR TITLE
build: deb, rpm, apk, and Arch Linux packages

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,6 +48,36 @@ archives:
       - README.md
       - LICENSE*
 
+nfpms:
+  - id: waggle
+    package_name: waggle
+    # nFPM only packages the linux artifacts of this build; darwin/windows
+    # are ignored. amd64 + arm64 both produce packages.
+    ids: [waggle]
+    maintainer: "Daniel Loader <hello@danielloader.uk>"
+    homepage: https://github.com/danielloader/waggle
+    description: |-
+      Local OpenTelemetry viewer for development.
+      OTLP/HTTP (4318) and OTLP/gRPC (4317) ingest into SQLite with a
+      Honeycomb-style trace/log/metric query UI, served from one binary.
+    license: GPL-3.0-only
+    # nFPM is bundled in goreleaser (zero-dependency); no rpmbuild/dpkg/fpm
+    # needed on the runner. Packages are unsigned — see the install notes.
+    formats:
+      - deb
+      - rpm
+      - apk
+      - archlinux
+    bindir: /usr/bin
+    # ConventionalFileName gives each packager its native arch naming
+    # (deb: amd64/arm64, rpm/apk: x86_64/aarch64).
+    file_name_template: "{{ .ConventionalFileName }}"
+    contents:
+      - src: README.md
+        dst: /usr/share/doc/waggle/README.md
+      - src: LICENSE
+        dst: /usr/share/doc/waggle/LICENSE
+
 kos:
   - id: waggle-docker
     build: waggle

--- a/README.md
+++ b/README.md
@@ -130,6 +130,25 @@ declines within that view.
 ./waggle
 ```
 
+**Linux packages** — `.deb`, `.rpm`, `.apk`, and Arch `.pkg.tar.zst` are
+attached to each [release](https://github.com/danielloader/waggle/releases)
+(amd64 + arm64). They install the binary to `/usr/bin/waggle`. Packages are
+**unsigned**, so some installers want an explicit "allow untrusted" flag:
+
+```sh
+# Debian / Ubuntu
+sudo dpkg -i waggle_*_amd64.deb
+
+# Fedora / RHEL / openSUSE
+sudo rpm -i waggle-*.x86_64.rpm        # or: sudo dnf install ./waggle-*.x86_64.rpm
+
+# Alpine (unsigned, hence --allow-untrusted)
+sudo apk add --allow-untrusted waggle_*_x86_64.apk
+
+# Arch
+sudo pacman -U waggle-*-x86_64.pkg.tar.zst
+```
+
 **Docker** — images are published to GitHub Container Registry:
 
 ```sh


### PR DESCRIPTION
## Summary
Adds an `nfpms` block to `.goreleaser.yaml` so every release also ships Linux packages, built by goreleaser's bundled nFPM (zero extra tooling on the runner):

- `.deb` (Debian/Ubuntu), `.rpm` (Fedora/RHEL/openSUSE), `.apk` (Alpine), and Arch `.pkg.tar.zst`
- amd64 + arm64 for each → 8 package assets per release
- binary installs to `/usr/bin/waggle`; `README`/`LICENSE` under `/usr/share/doc/waggle/`

Packages are **unsigned** — fine for direct download + install. Signing (cosign keyless + SBOM, or GPG) is only worth it if a hosted apt/dnf repo is ever stood up; deferred.

The existing `release.yml` needs no changes — goreleaser picks up the new block. README install section documents the per-distro commands.

## Test plan
- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean --skip=ko` produces all 8 packages (deb/rpm/apk/arch × amd64/arm64)
- [x] Verified package layout: `/usr/bin/waggle` + `/usr/share/doc/waggle/{README.md,LICENSE}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)