### PR TITLE
build: publish a Homebrew cask to danielloader/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with contents:write on danielloader/homebrew-tap, so
+          # goreleaser can commit the generated Formula to the tap repo.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -78,6 +78,36 @@ nfpms:
       - src: LICENSE
         dst: /usr/share/doc/waggle/LICENSE
 
+# Homebrew Cask (macOS). goreleaser deprecated `brews` (formulas) for
+# prebuilt binaries in favour of casks; casks are macOS-only, which is fine
+# here — Linux users have the nfpm packages above. Users install with
+# `brew install danielloader/tap/waggle`.
+homebrew_casks:
+  - name: waggle
+    # Tap lives in a separate repo, so the default GITHUB_TOKEN (scoped to
+    # this repo) can't push to it — HOMEBREW_TAP_TOKEN is a PAT with
+    # contents:write on danielloader/homebrew-tap, passed in release.yml.
+    repository:
+      owner: danielloader
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/danielloader/waggle
+    description: Local OpenTelemetry viewer — OTLP/HTTP + OTLP/gRPC ingest into SQLite + Honeycomb-style UI
+    # Skip publishing for prereleases (e.g. v1.2.3-rc1).
+    skip_upload: auto
+    # homepage and download host are the same domain; helps `brew audit`.
+    url:
+      verified: github.com/danielloader/waggle
+    # The binary is unsigned, so strip the Gatekeeper quarantine xattr on
+    # install — otherwise macOS blocks it with "developer cannot be verified".
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/waggle"]
+          end
+
 kos:
   - id: waggle-docker
     build: waggle
@@ -144,6 +174,11 @@ release:
     Local OpenTelemetry viewer — OTLP/HTTP (4318) and OTLP/gRPC (4317) ingest into SQLite + Honeycomb-style UI.
   footer: |
     ### Install
+
+    **Homebrew** (macOS)
+    ```
+    brew install --cask danielloader/tap/waggle
+    ```
 
     **Binary** — download from the assets below, extract, and run:
     ```

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ declines within that view.
 
 ## Install
 
+**Homebrew** — macOS, via the tap (Linux: use the packages below):
+
+```sh
+brew install --cask danielloader/tap/waggle
+```
+
 **Binary** — grab a release archive from
 [Releases](https://github.com/danielloader/waggle/releases), extract, and run:
 


### PR DESCRIPTION
## Summary
Adds a `homebrew_casks` block so each non-prerelease release generates and commits a Homebrew **Cask** to `danielloader/homebrew-tap`:

```sh
brew install --cask danielloader/tap/waggle   # macOS
```

### Why a cask, not a formula
goreleaser has **deprecated `brews`** (formulas) for prebuilt binaries — Homebrew formulas are meant to build from source, and a binary-download formula is a hack that homebrew-core disallows. Casks are Homebrew's sanctioned channel for prebuilt artifacts. Trade-off: casks are macOS-only (Linuxbrew doesn't support them), which is fine here — Linux is covered by the deb/rpm/apk/arch packages.

### Details
- **Unsigned binary** → a `postflight` hook strips the macOS Gatekeeper quarantine xattr, so users don't hit "developer cannot be verified".
- **Cross-repo push**: the default `GITHUB_TOKEN` is scoped to this repo and can't write to the tap, so `release.yml` passes `HOMEBREW_TAP_TOKEN` (a PAT with contents:write on `danielloader/homebrew-tap`).
- `skip_upload: auto` so prereleases (`-rc1`) don't publish to the tap.
- README + release-notes footer document the `--cask` install command.

## Prerequisites (done)
- `danielloader/homebrew-tap` repo exists (public)
- `HOMEBREW_TAP_TOKEN` secret set on this repo

## Test plan
- [x] `goreleaser check` passes (no deprecation warnings)
- [x] `goreleaser release --snapshot --clean --skip=ko` generates `dist/homebrew/Casks/waggle.rb` with per-arch sha256, `binary "waggle"`, `verified` URL, and the quarantine postflight hook
- [ ] First release after merge publishes the cask to the tap → `brew install --cask danielloader/tap/waggle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)