### PR TITLE
ci: bump release actions off Node 20 (docker/login v4, goreleaser v7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,14 @@ jobs:
           cp -R ui/dist/. internal/ui/dist/
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary
GitHub is force-migrating Node 20 actions to Node 24 on **2026-06-02**, and the v0.17.0 release run flagged two actions still on Node 20:

- `docker/login-action@v3` → **@v4** (v4.2.0, Node 24)
- `goreleaser/goreleaser-action@v6` → **@v7** (v7.2.2, Node 24)

Same inputs on both — no other changes needed. The remaining actions (`checkout@v5`, `setup-node@v5`, `setup-go@v6`) are already on Node 24, which is why only these two were flagged.

The release workflow only runs on tags, so this won't be exercised until the next release — merging ahead of the June 2 cutover avoids a surprise then.

## Test plan
- [x] Confirmed v4.2.0 / v7.2.2 are the current latest majors
- [x] goreleaser-action v7 takes the same `distribution`/`version`/`args` inputs already in use
- [ ] Next tagged release runs clean on the bumped actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)