### PR TITLE
fix(retention): cull catalog tables, sweep at startup, add Clear-data button

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,8 +41,10 @@ tasks:
     cmds:
       - cd {{.VITE_DIR}} && npm ci
       - cd {{.VITE_DIR}} && npm run build
-      - rm -rf {{.UI_DIST}}
+      # Clear stale hashed bundles but keep the tracked .gitkeep that holds
+      # the (otherwise gitignored) embed dir in the repo.
       - mkdir -p {{.UI_DIST}}
+      - find {{.UI_DIST}} -mindepth 1 ! -name .gitkeep -delete
       - cp -R {{.VITE_DIR}}/dist/. {{.UI_DIST}}/
     sources:
       - "{{.VITE_DIR}}/src/**/*"

--- a/cmd/waggle/main.go
+++ b/cmd/waggle/main.go
@@ -171,6 +171,15 @@ func retentionSweep(ctx context.Context, log *slog.Logger, st *sqlite.Store, ret
 	if retention <= 0 {
 		return
 	}
+	sweep := func(now time.Time) {
+		cutoff := now.Add(-retention).UnixNano()
+		if err := st.Retain(ctx, cutoff); err != nil {
+			log.Warn("retention sweep failed", "err", err)
+		}
+	}
+	// Sweep once at startup so a restart doesn't leave stale data sitting for up
+	// to a full tick (and a sub-tick restart loop still culls).
+	sweep(time.Now())
 	t := time.NewTicker(10 * time.Minute)
 	defer t.Stop()
 	for {
@@ -178,10 +187,7 @@ func retentionSweep(ctx context.Context, log *slog.Logger, st *sqlite.Store, ret
 		case <-ctx.Done():
 			return
 		case now := <-t.C:
-			cutoff := now.Add(-retention).UnixNano()
-			if err := st.Retain(ctx, cutoff); err != nil {
-				log.Warn("retention sweep failed", "err", err)
-			}
+			sweep(now)
 		}
 	}
 }

--- a/internal/store/sqlite/queries.go
+++ b/internal/store/sqlite/queries.go
@@ -1195,6 +1195,22 @@ func (s *Store) Retain(ctx context.Context, olderThanNS int64) error {
 		olderThanNS); err != nil {
 		return err
 	}
+	// Scopes have no timestamp of their own; drop any no longer referenced by a
+	// surviving event or metric. The IS NOT NULL guards keep the NOT IN from
+	// short-circuiting to "match nothing" on the nullable scope_id columns.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM scopes
+		WHERE scope_id NOT IN (SELECT scope_id FROM events WHERE scope_id IS NOT NULL)
+		  AND scope_id NOT IN (SELECT scope_id FROM metric_events WHERE scope_id IS NOT NULL)`); err != nil {
+		return err
+	}
+	// Attribute catalog rollups carry their own last_seen_ns, so they age out on
+	// the same cutoff as the events that fed them.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM attribute_keys WHERE last_seen_ns < ?`, olderThanNS); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM attribute_values WHERE last_seen_ns < ?`, olderThanNS); err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 

--- a/internal/store/sqlite/retain_test.go
+++ b/internal/store/sqlite/retain_test.go
@@ -224,3 +224,94 @@ func TestRetain_OldResourceWithRecentEvent(t *testing.T) {
 		t.Fatalf("expected 1 resource (still referenced by the recent event), got %d", n)
 	}
 }
+
+// Attribute catalog rollups carry their own last_seen_ns and must age out on
+// the same cutoff as events — otherwise the Fields panel keeps surfacing keys
+// and values from data that was culled long ago.
+func TestRetain_PrunesAttributeCatalog(t *testing.T) {
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "retain.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	now := time.Now().UnixNano()
+	old := now - int64(2*time.Hour)
+	recent := now - int64(5*time.Minute)
+
+	if _, err := s.WriterDB().ExecContext(ctx, `INSERT INTO attribute_keys
+		(signal_type, service_name, key, value_type, first_seen_ns, last_seen_ns, count)
+		VALUES ('span','svc','old.key','str',?,?,1), ('span','svc','new.key','str',?,?,1)`,
+		old, old, recent, recent); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.WriterDB().ExecContext(ctx, `INSERT INTO attribute_values
+		(signal_type, service_name, key, value, count, last_seen_ns)
+		VALUES ('span','svc','k','old',1,?), ('span','svc','k','new',1,?)`,
+		old, recent); err != nil {
+		t.Fatal(err)
+	}
+
+	cutoff := now - int64(time.Hour)
+	if err := s.Retain(ctx, cutoff); err != nil {
+		t.Fatalf("Retain: %v", err)
+	}
+
+	var keys, vals int
+	if err := s.ReaderDB().QueryRowContext(ctx, "SELECT COUNT(*) FROM attribute_keys").Scan(&keys); err != nil {
+		t.Fatal(err)
+	}
+	if keys != 1 {
+		t.Fatalf("expected 1 attribute_key (new.key), got %d", keys)
+	}
+	if err := s.ReaderDB().QueryRowContext(ctx, "SELECT COUNT(*) FROM attribute_values").Scan(&vals); err != nil {
+		t.Fatal(err)
+	}
+	if vals != 1 {
+		t.Fatalf("expected 1 attribute_value (new), got %d", vals)
+	}
+}
+
+// A scope referenced only by culled events becomes an orphan and should be
+// dropped; a scope still referenced by a surviving event must be kept.
+func TestRetain_DeletesOrphanedScope_KeepsReferenced(t *testing.T) {
+	ctx := context.Background()
+	s, err := Open(ctx, filepath.Join(t.TempDir(), "retain.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	now := time.Now().UnixNano()
+	old := now - int64(2*time.Hour)
+	recent := now - int64(5*time.Minute)
+
+	// Old batch: resource 1, scope 10 (becomes orphaned once its event is culled).
+	if err := s.WriteBatch(ctx, mkBatch(1, 10, 0xAA, old)); err != nil {
+		t.Fatal(err)
+	}
+	// Recent batch: resource 2, scope 20 (stays referenced).
+	if err := s.WriteBatch(ctx, mkBatch(2, 20, 0xBB, recent)); err != nil {
+		t.Fatal(err)
+	}
+
+	cutoff := now - int64(time.Hour)
+	if err := s.Retain(ctx, cutoff); err != nil {
+		t.Fatalf("Retain: %v", err)
+	}
+
+	var n int
+	if err := s.ReaderDB().QueryRowContext(ctx, "SELECT COUNT(*) FROM scopes WHERE scope_id = 10").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("expected orphaned scope 10 deleted, got %d", n)
+	}
+	if err := s.ReaderDB().QueryRowContext(ctx, "SELECT COUNT(*) FROM scopes WHERE scope_id = 20").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("expected referenced scope 20 kept, got %d", n)
+	}
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -102,6 +102,14 @@ async function getJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
   return (await res.json()) as T;
 }
 
+async function postJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(url, { method: "POST", signal });
+  if (!res.ok) {
+    throw new HttpError(res.status, res.statusText, await res.text());
+  }
+  return (await res.json()) as T;
+}
+
 export const api = {
   listServices: (dataset: string, signal?: AbortSignal) =>
     getJSON<{ services: ServiceSummary[] }>(
@@ -147,6 +155,10 @@ export const api = {
   // can branch on `err.status === 404` to fall back gracefully.
   getHistoryByHash: (hash: string, signal?: AbortSignal) =>
     getJSON<QueryHistoryEntry>(`/api/history/${hash}`, signal),
+
+  // Wipe all ingested telemetry. Destructive; the caller confirms first.
+  clear: (signal?: AbortSignal) =>
+    postJSON<{ ok: boolean }>(`/api/clear`, signal),
 };
 
 export interface QueryHistoryEntry {

--- a/ui/src/routes/root.tsx
+++ b/ui/src/routes/root.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
 import { Link, Outlet, useLocation } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Activity,
   History,
   PanelLeftClose,
   PanelLeft,
+  Trash2,
 } from "lucide-react";
 import clsx from "clsx";
+
+import { api } from "../lib/api";
 
 const STORAGE_KEY = "waggle.sidebar.collapsed";
 
@@ -26,6 +29,23 @@ export function RootLayout() {
   useEffect(() => {
     window.localStorage.setItem(STORAGE_KEY, collapsed ? "1" : "0");
   }, [collapsed]);
+
+  const queryClient = useQueryClient();
+  const clearData = useMutation({
+    mutationFn: () => api.clear(),
+    onSuccess: () => queryClient.invalidateQueries(),
+  });
+
+  const onClear = () => {
+    if (clearData.isPending) return;
+    if (
+      window.confirm(
+        "Clear all ingested telemetry? This permanently deletes every event, metric, trace, and field. This cannot be undone.",
+      )
+    ) {
+      clearData.mutate();
+    }
+  };
 
   // Health probe — reads back the server's real listen address so the
   // footer doesn't lie when waggle runs on a non-default --addr.
@@ -121,6 +141,23 @@ export function RootLayout() {
             <History />,
             pathname.startsWith("/history"),
           )}
+          <button
+            type="button"
+            onClick={onClear}
+            disabled={clearData.isPending}
+            className={clsx(
+              "mt-auto flex items-center rounded-md text-sm text-[var(--color-error)] hover:bg-[var(--color-error)]/10 disabled:opacity-50",
+              collapsed ? "justify-center p-2" : "gap-2 px-3 py-2",
+            )}
+            title={collapsed ? "Clear data" : undefined}
+          >
+            <span className="w-4 h-4 flex items-center justify-center">
+              <Trash2 className="w-4 h-4" />
+            </span>
+            {!collapsed && (
+              <span>{clearData.isPending ? "Clearing…" : "Clear data"}</span>
+            )}
+          </button>
         </nav>
         <div
           className={clsx(


### PR DESCRIPTION
## Summary
Investigated whether max-age culling was working. The age cutoff was correct for event-shaped rows, but `Retain` never touched the dimension/catalog tables, so they grew unbounded under retention. This PR closes that gap plus two related fixes.

- **Cull catalog tables in `Retain`** (`internal/store/sqlite/queries.go`): drop orphaned `scopes` (no surviving `events`/`metric_events` reference, with `IS NOT NULL` guards so the nullable `scope_id` doesn't trip the `NOT IN`/NULL trap) and age out `attribute_keys`/`attribute_values` on the same `last_seen_ns < cutoff` cutoff. These rows back the Fields panel/autocomplete and were previously only cleared by a full `Clear()`.
- **Sweep once at startup** (`cmd/waggle/main.go`): `retentionSweep` previously only acted on the 10-minute ticker, so a restart left stale data for up to a full tick (and a sub-tick restart loop never culled). Now runs one sweep before entering the loop.
- **"Clear data" button in the left nav** (`ui/src/routes/root.tsx`, `ui/src/lib/api.ts`): one-click wipe wired to the existing `POST /api/clear`, with a confirm prompt and React Query cache invalidation.

## Test plan
- [x] `go test ./...` — all packages pass, including new `TestRetain_PrunesAttributeCatalog` and `TestRetain_DeletesOrphanedScope_KeepsReferenced`
- [x] `go vet ./...` clean
- [x] UI `tsc --noEmit`, `eslint`, and `vite build` clean
- [x] Smoke-tested `POST /api/clear` → `{"ok":true}`
- [x] Verified the Clear-data button renders in the sidebar (built embed + browser check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)