### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,7 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X main.version={{ .Version }}
 
 archives:
   - id: default

--- a/cmd/waggle/main.go
+++ b/cmd/waggle/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -21,6 +22,10 @@ import (
 	"github.com/danielloader/waggle/internal/store/sqlite"
 )
 
+// version is the build version, overridden at release time via
+// -ldflags "-X main.version=...". Defaults to "dev" for local builds.
+var version = "dev"
+
 func main() {
 	// `waggle mcp` runs the read-only MCP server over stdio against a database
 	// file, for clients (e.g. Claude) that spawn the process directly. It must
@@ -37,6 +42,11 @@ func main() {
 	if err != nil {
 		slog.Error("invalid config", "err", err)
 		os.Exit(2)
+	}
+
+	if cfg.Version {
+		fmt.Println(version)
+		return
 	}
 
 	log := newLogger(cfg.LogLevel)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	LogLevel      string
 	Dev           bool
 
+	// Version, when set via --version, makes main print the build version
+	// and exit before starting any listeners.
+	Version bool
+
 	// MCPEnabled mounts the read-only Model Context Protocol endpoint at
 	// /mcp on the UI listener, letting an MCP client (e.g. Claude) explore
 	// stored traces/metrics/logs. Defaults on; the surface is read-only and
@@ -50,6 +54,7 @@ func Load() (*Config, error) {
 	retentionStr := flag.String("retention", envOr("WAGGLE_RETENTION", "24h"), "Drop data older than this")
 	flag.StringVar(&c.LogLevel, "log-level", envOr("WAGGLE_LOG_LEVEL", "info"), "slog level: debug, info, warn, error")
 	flag.BoolVar(&c.Dev, "dev", false, "Dev mode: do not serve embedded UI and do not open browser")
+	flag.BoolVar(&c.Version, "version", false, "Print version and exit")
 	flag.BoolVar(&c.MCPEnabled, "mcp", envBool("WAGGLE_MCP", true), "Serve the read-only MCP endpoint at /mcp on the UI listener")
 
 	flag.StringVar(&c.TeePath, "tee", envOr("WAGGLE_TEE", ""), "Mirror log records to this path (use '-' for stdout)")


### PR DESCRIPTION
## Summary
`waggle` had no way to report its build version (`waggle --version` errored with "flag provided but not defined"). This adds one.

- `--version` (also `-version`) prints the version and exits before any listeners start.
- Backed by a `main.version` package var defaulting to `"dev"` for local builds.
- goreleaser stamps the real version via `-ldflags "-X main.version={{ .Version }}"` at release time.
- Registered on the global flag set, so it also shows up in `waggle -h`.

## Test plan
- [x] `go vet ./...` / `go build ./...` clean
- [x] `goreleaser check` passes with the new ldflags template
- [x] `waggle --version` → `dev` for a local `go build`
- [x] `go build -ldflags "-X main.version=0.17.2"` → `waggle -version` prints `0.17.2`
- [x] Flag appears in `waggle -h`

🤖 Generated with [Claude Code](https://claude.com/claude-code)