### PR TITLE
feat(config): default --db-path to OS user-data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ All flags have matching environment variables. Flags take precedence.
 
 | Flag | Env | Default | Notes |
 | --- | --- | --- | --- |
-| `--db-path` | `WAGGLE_DB` | `./waggle.db` | SQLite file path. |
+| `--db-path` | `WAGGLE_DB` | OS user-data dir | SQLite file path. Defaults to `$XDG_DATA_HOME/waggle/waggle.db` (Linux, falling back to `~/.local/share/waggle/waggle.db`), `~/Library/Application Support/waggle/waggle.db` (macOS), or `%LocalAppData%\waggle\waggle.db` (Windows). Parent directories are created on first run. |
 | `--addr` | `WAGGLE_ADDR` | `127.0.0.1:4318` | Bind address for UI, API, and OTLP/HTTP ingest. |
 | `--ingest-addr` | `WAGGLE_INGEST_ADDR` | — | Override to split OTLP/HTTP ingest onto its own listener. |
 | `--ui-addr` | `WAGGLE_UI_ADDR` | — | Override to split the UI + API onto its own listener. |

--- a/cmd/waggle/main.go
+++ b/cmd/waggle/main.go
@@ -132,7 +132,7 @@ func main() {
 // file. Logs go to stderr so stdout stays clean for the MCP protocol.
 func runMCPStdio(args []string) error {
 	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
-	dbPath := fs.String("db-path", envOr("WAGGLE_DB", "./waggle.db"), "SQLite file path")
+	dbPath := fs.String("db-path", envOr("WAGGLE_DB", config.DefaultDBPath()), "SQLite file path (defaults to the OS user-data dir)")
 	logLevel := fs.String("log-level", envOr("WAGGLE_LOG_LEVEL", "info"), "slog level: debug, info, warn, error")
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/Ladicle/tabwriter v1.0.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/adrg/xdg v0.5.3 // indirect
 	github.com/alecthomas/chroma/v2 v2.23.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/Ladicle/tabwriter v1.0.0 h1:DZQqPvMumBDwVNElso13afjYLNp0Z7pHqHnu0r4t9
 github.com/Ladicle/tabwriter v1.0.0/go.mod h1:c4MdCjxQyTbGuQO/gvqJ+IA/89UEwrsD6hUCW98dyp4=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/adrg/xdg"
 )
 
 type Config struct {
@@ -45,7 +48,7 @@ type Config struct {
 func Load() (*Config, error) {
 	c := &Config{}
 
-	flag.StringVar(&c.DBPath, "db-path", envOr("WAGGLE_DB", "./waggle.db"), "SQLite file path")
+	flag.StringVar(&c.DBPath, "db-path", envOr("WAGGLE_DB", DefaultDBPath()), "SQLite file path (defaults to the OS user-data dir)")
 	flag.StringVar(&c.Addr, "addr", envOr("WAGGLE_ADDR", "127.0.0.1:4318"), "Bind address for UI, API, and OTLP ingest")
 	flag.StringVar(&c.IngestAddr, "ingest-addr", envOr("WAGGLE_INGEST_ADDR", ""), "Override address for OTLP ingest (default: same as --addr)")
 	flag.StringVar(&c.UIAddr, "ui-addr", envOr("WAGGLE_UI_ADDR", ""), "Override address for UI + API (default: same as --addr)")
@@ -127,6 +130,18 @@ func parseTeeSeverity(s string) (int32, error) {
 
 func (c *Config) SplitListeners() bool {
 	return c.IngestAddr != c.UIAddr
+}
+
+// DefaultDBPath returns the OS-specific path where waggle stores its SQLite
+// database when neither --db-path nor WAGGLE_DB is set. Resolution is handled
+// by github.com/adrg/xdg, which maps XDG_DATA_HOME to ~/Library/Application
+// Support on macOS and %LOCALAPPDATA% on Windows. Falls back to ./waggle.db
+// if the user-data dir cannot be resolved.
+func DefaultDBPath() string {
+	if xdg.DataHome == "" {
+		return "./waggle.db"
+	}
+	return filepath.Join(xdg.DataHome, "waggle", "waggle.db")
 }
 
 func envOr(k, def string) string {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -7,6 +7,8 @@ import (
 	_ "embed"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 
@@ -35,9 +37,17 @@ type Store struct {
 }
 
 // Open opens (or creates) the SQLite file at path and applies the schema.
+// Missing parent directories are created so the OS-specific default location
+// (and any user-supplied nested path) just works on first run.
 func Open(ctx context.Context, path string) (*Store, error) {
 	if err := registerFunctions(); err != nil {
 		return nil, err
+	}
+
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create db dir %q: %w", dir, err)
+		}
 	}
 
 	writer, err := openPool(path, 1)


### PR DESCRIPTION
## Summary
- Default `--db-path` (and `WAGGLE_DB`) now resolve via `github.com/adrg/xdg` to the OS user-data dir instead of `./waggle.db`:
  - Linux: `$XDG_DATA_HOME/waggle/waggle.db` (falls back to `~/.local/share/waggle/waggle.db`)
  - macOS: `~/Library/Application Support/waggle/waggle.db`
  - Windows: `%LOCALAPPDATA%\waggle\waggle.db`
- `--db-path` / `WAGGLE_DB` still override (including the `waggle mcp` stdio subcommand).
- `sqlite.Open` now `MkdirAll`s the parent directory so first run works without manual setup, and any user-supplied nested path Just Works.

## Test plan
- [x] `go build ./...`
- [x] `waggle --help` shows the resolved per-OS default
- [ ] Verify on Linux that `XDG_DATA_HOME` is honoured and that the fallback to `~/.local/share` works
- [ ] Verify on Windows that `%LOCALAPPDATA%` is used